### PR TITLE
Reverse order of OnActionExecuting/Executed definition

### DIFF
--- a/src/Autofac.Integration.WebApi/ActionFilterWrapper.cs
+++ b/src/Autofac.Integration.WebApi/ActionFilterWrapper.cs
@@ -67,33 +67,6 @@ namespace Autofac.Integration.WebApi
         }
 
         /// <summary>
-        /// Occurs after the action method is invoked.
-        /// </summary>
-        /// <param name="actionExecutedContext">The context for the action.</param>
-        /// <param name="cancellationToken">A cancellation token for signaling task ending.</param>
-        /// <exception cref="System.ArgumentNullException">
-        /// Thrown if <paramref name="actionExecutedContext" /> is <see langword="null" />.
-        /// </exception>
-        public override async Task OnActionExecutedAsync(HttpActionExecutedContext actionExecutedContext, CancellationToken cancellationToken)
-        {
-            if (actionExecutedContext == null)
-            {
-                throw new ArgumentNullException(nameof(actionExecutedContext));
-            }
-
-            var dependencyScope = actionExecutedContext.Request.GetDependencyScope();
-            var lifetimeScope = dependencyScope.GetRequestLifetimeScope();
-
-            var filters = lifetimeScope.Resolve<IEnumerable<Meta<Lazy<IAutofacActionFilter>>>>();
-
-            // Issue #16: OnActionExecuted needs to happen in the opposite order of OnActionExecuting.
-            foreach (var filter in filters.Where(this.FilterMatchesMetadata).Reverse())
-            {
-                await filter.Value.Value.OnActionExecutedAsync(actionExecutedContext, cancellationToken);
-            }
-        }
-
-        /// <summary>
         /// Occurs before the action method is invoked.
         /// </summary>
         /// <param name="actionContext">The context for the action.</param>
@@ -117,6 +90,33 @@ namespace Autofac.Integration.WebApi
             foreach (var filter in filters.Where(this.FilterMatchesMetadata))
             {
                 await filter.Value.Value.OnActionExecutingAsync(actionContext, cancellationToken);
+            }
+        }
+
+        /// <summary>
+        /// Occurs after the action method is invoked.
+        /// </summary>
+        /// <param name="actionExecutedContext">The context for the action.</param>
+        /// <param name="cancellationToken">A cancellation token for signaling task ending.</param>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown if <paramref name="actionExecutedContext" /> is <see langword="null" />.
+        /// </exception>
+        public override async Task OnActionExecutedAsync(HttpActionExecutedContext actionExecutedContext, CancellationToken cancellationToken)
+        {
+            if (actionExecutedContext == null)
+            {
+                throw new ArgumentNullException(nameof(actionExecutedContext));
+            }
+
+            var dependencyScope = actionExecutedContext.Request.GetDependencyScope();
+            var lifetimeScope = dependencyScope.GetRequestLifetimeScope();
+
+            var filters = lifetimeScope.Resolve<IEnumerable<Meta<Lazy<IAutofacActionFilter>>>>();
+
+            // Issue #16: OnActionExecuted needs to happen in the opposite order of OnActionExecuting.
+            foreach (var filter in filters.Where(this.FilterMatchesMetadata).Reverse())
+            {
+                await filter.Value.Value.OnActionExecutedAsync(actionExecutedContext, cancellationToken);
             }
         }
 

--- a/src/Autofac.Integration.WebApi/IAutofacActionFilter.cs
+++ b/src/Autofac.Integration.WebApi/IAutofacActionFilter.cs
@@ -36,17 +36,17 @@ namespace Autofac.Integration.WebApi
     public interface IAutofacActionFilter
     {
         /// <summary>
-        /// Occurs after the action method is invoked.
-        /// </summary>
-        /// <param name="actionExecutedContext">The context for the action.</param>
-        /// <param name="cancellationToken">A cancellation token for signaling task ending.</param>
-        Task OnActionExecutedAsync(HttpActionExecutedContext actionExecutedContext, CancellationToken cancellationToken);
-
-        /// <summary>
         /// Occurs before the action method is invoked.
         /// </summary>
         /// <param name="actionContext">The context for the action.</param>
         /// <param name="cancellationToken">A cancellation token for signaling task ending.</param>
         Task OnActionExecutingAsync(HttpActionContext actionContext, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Occurs after the action method is invoked.
+        /// </summary>
+        /// <param name="actionExecutedContext">The context for the action.</param>
+        /// <param name="cancellationToken">A cancellation token for signaling task ending.</param>
+        Task OnActionExecutedAsync(HttpActionExecutedContext actionExecutedContext, CancellationToken cancellationToken);
     }
 }


### PR DESCRIPTION
I always find myself switching OnActionExecuting/OnActionExecuted methods whenever I implement the IAutofacActionFilter interface so the methods are in the logical order (before and then after). Looks like you already did this in the [TestTypes](https://github.com/autofac/Autofac.WebApi/blob/64451cce1e6be4b312a20c71df8743897f30480e/test/Autofac.Integration.WebApi.Test/TestTypes.cs#L294-L302) as well.

Simply switched the complete code blocks, but git diff likes to make a mess of it.