### PR TITLE
:zap: Make dependency resolver extensible.

### DIFF
--- a/src/Autofac.Integration.WebApi/AutofacWebApiDependencyResolver.cs
+++ b/src/Autofac.Integration.WebApi/AutofacWebApiDependencyResolver.cs
@@ -86,7 +86,7 @@ namespace Autofac.Integration.WebApi
         /// </summary>
         /// <param name="serviceType">Type of service to request.</param>
         /// <returns>An instance of the service, or null if the service is not found.</returns>
-        public object GetService(Type serviceType)
+        public virtual object GetService(Type serviceType)
         {
             return _rootDependencyScope.GetService(serviceType);
         }
@@ -96,7 +96,7 @@ namespace Autofac.Integration.WebApi
         /// </summary>
         /// <param name="serviceType">ControllerType of services to request.</param>
         /// <returns>An enumeration (possibly empty) of the service.</returns>
-        public IEnumerable<object> GetServices(Type serviceType)
+        public virtual IEnumerable<object> GetServices(Type serviceType)
         {
             return _rootDependencyScope.GetServices(serviceType);
         }


### PR DESCRIPTION
Similar to what is described in [Autofac Issue #638](https://github.com/autofac/Autofac/issues/638), I would like to extend `AutofacWebApiDependencyResolver` to add custom logic.  The `GetService` and `GetServices` methods of [AutofacDependencyResolver in Autofac.Mvc](https://github.com/autofac/Autofac.Mvc/blob/develop/src/Autofac.Integration.Mvc/AutofacDependencyResolver.cs) were made virtual to solve this issue, I would like to do the same here.