### PR TITLE
Feature/use accessor for httprequestmessage

### DIFF
--- a/src/Autofac.Integration.WebApi/Autofac.Integration.WebApi.csproj
+++ b/src/Autofac.Integration.WebApi/Autofac.Integration.WebApi.csproj
@@ -74,6 +74,7 @@
     <Compile Include="ActionFilterWrapper.cs" />
     <Compile Include="AuthorizationFilterWrapper.cs" />
     <Compile Include="ActionFilterOverrideWrapper.cs" />
+    <Compile Include="AutofacHttpRequestMessageProvider.cs" />
     <Compile Include="AutofacOverrideFilter.cs" />
     <Compile Include="AutofacWebApiDependencyResolver.cs" />
     <Compile Include="AutofacWebApiDependencyScope.cs" />

--- a/src/Autofac.Integration.WebApi/AutofacHttpRequestMessageProvider.cs
+++ b/src/Autofac.Integration.WebApi/AutofacHttpRequestMessageProvider.cs
@@ -1,0 +1,34 @@
+﻿// This software is part of the Autofac IoC container
+// Copyright (c) 2013 Autofac Contributors
+// http://autofac.org
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+using System.Net.Http;
+
+namespace Autofac.Integration.WebApi
+{
+    internal static class AutofacHttpRequestMessageProvider
+    {
+        internal static HttpRequestMessage Current { get; set; }
+    }
+}

--- a/src/Autofac.Integration.WebApi/AutofacHttpRequestMessageProvider.cs
+++ b/src/Autofac.Integration.WebApi/AutofacHttpRequestMessageProvider.cs
@@ -23,12 +23,39 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
+using System;
 using System.Net.Http;
+using System.Runtime.Remoting.Messaging;
 
 namespace Autofac.Integration.WebApi
 {
     internal static class AutofacHttpRequestMessageProvider
     {
-        internal static HttpRequestMessage Current { get; set; }
+        private static readonly string _key = Guid.NewGuid().ToString("N").Substring(0, 12);
+
+        internal static HttpRequestMessage Current
+        {
+            get
+            {
+                var wrapper = (HttpRequestMessageWrapper)CallContext.LogicalGetData(_key);
+                return wrapper?.Message;
+            }
+            set
+            {
+                var wrapper = value == null ? null : new HttpRequestMessageWrapper(value);
+                CallContext.LogicalSetData(_key, wrapper);
+            }
+        }
+
+        [Serializable]
+        internal sealed class HttpRequestMessageWrapper : MarshalByRefObject
+        {
+            [NonSerialized] internal readonly HttpRequestMessage Message;
+
+            internal HttpRequestMessageWrapper(HttpRequestMessage message)
+            {
+                Message = message;
+            }
+        }
     }
 }

--- a/src/Autofac.Integration.WebApi/CurrentRequestHandler.cs
+++ b/src/Autofac.Integration.WebApi/CurrentRequestHandler.cs
@@ -30,8 +30,8 @@ using System.Threading.Tasks;
 namespace Autofac.Integration.WebApi
 {
     /// <summary>
-    /// A delegating handler that updates the current dependency scope
-    /// with the current <see cref="HttpRequestMessage"/>.
+    /// A delegating handler that sets the current <see cref="HttpRequestMessage"/> to 
+    /// <see cref="AutofacHttpRequestMessageProvider.Current"/>.
     /// </summary>
     class CurrentRequestHandler : DelegatingHandler
     {
@@ -51,19 +51,12 @@ namespace Autofac.Integration.WebApi
         }
 
         /// <summary>
-        /// Updates the current dependency scope with current HTTP request message.
+        /// Sets the current HTTP request message to <see cref="AutofacHttpRequestMessageProvider.Current"/>.
         /// </summary>
         /// <param name="request">The HTTP request message.</param>
         internal static void UpdateScopeWithHttpRequestMessage(HttpRequestMessage request)
         {
-            var scope = request.GetDependencyScope();
-            var requestScope = scope.GetRequestLifetimeScope();
-            if (requestScope == null) return;
-
-            var registry = requestScope.ComponentRegistry;
-            var builder = new ContainerBuilder();
-            builder.Register(c => request).InstancePerRequest();
-            builder.Update(registry);
+            AutofacHttpRequestMessageProvider.Current = request;
         }
     }
 }

--- a/src/Autofac.Integration.WebApi/HttpConfigurationExtensions.cs
+++ b/src/Autofac.Integration.WebApi/HttpConfigurationExtensions.cs
@@ -55,5 +55,30 @@ namespace Autofac.Integration.WebApi
 
             IsHttpRequestMessageTrackingEnabled = true;
         }
+
+        /// <summary>
+        /// Returns the current <see cref="HttpRequestMessage"/> from <see cref="AutofacHttpRequestMessageProvider.Current"/>.
+        /// </summary>
+        /// <param name="componentContext">The Autofac <see cref="IComponentContext"/></param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="componentContext"/> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">Thrown if <see cref="HttpConfigurationExtensions.IsHttpRequestMessageTrackingEnabled"/> is
+        /// <see langword="false" />
+        /// </exception>
+        /// <returns></returns>
+        public static HttpRequestMessage GetHttpRequestMessage(this IComponentContext componentContext)
+        {
+            if (componentContext == null) throw new ArgumentNullException(nameof(componentContext));
+
+            if (!IsHttpRequestMessageTrackingEnabled)
+            {
+                throw new InvalidOperationException(
+                    "Cannot resolve the current HttpRequestMessage. " +
+                    "Please make sure containerBuilder.RegisterHttpRequestMessage" +
+                    "(GlobalConfiguration.Configuration) is called during startup");
+            }
+
+            return AutofacHttpRequestMessageProvider.Current;
+        }
     }
 }

--- a/src/Autofac.Integration.WebApi/HttpConfigurationExtensions.cs
+++ b/src/Autofac.Integration.WebApi/HttpConfigurationExtensions.cs
@@ -35,6 +35,8 @@ namespace Autofac.Integration.WebApi
     /// </summary>
     public static class HttpConfigurationExtensions
     {
+        internal static bool IsHttpRequestMessageTrackingEnabled = false;
+
         /// <summary>
         /// Makes the current <see cref="HttpRequestMessage"/> resolvable through the dependency scope.
         /// </summary>
@@ -50,6 +52,8 @@ namespace Autofac.Integration.WebApi
             {
                 config.MessageHandlers.Add(new CurrentRequestHandler());
             }
+
+            IsHttpRequestMessageTrackingEnabled = true;
         }
     }
 }

--- a/test/Autofac.Integration.WebApi.Test/Autofac.Integration.WebApi.Test.csproj
+++ b/test/Autofac.Integration.WebApi.Test/Autofac.Integration.WebApi.Test.csproj
@@ -81,6 +81,7 @@
   <ItemGroup>
     <Compile Include="ActionFilterFixture.cs" />
     <Compile Include="ActionFilterWrapperFixture.cs" />
+    <Compile Include="AutofacHttpRequestMessageProviderFixture.cs" />
     <Compile Include="AutofacWebApiDependencyResolverFixture.cs" />
     <Compile Include="AutofacWebApiFilterProviderFixture.cs" />
     <Compile Include="AutofacWebApiModelBinderProviderFixture.cs" />

--- a/test/Autofac.Integration.WebApi.Test/AutofacHttpRequestMessageProviderFixture.cs
+++ b/test/Autofac.Integration.WebApi.Test/AutofacHttpRequestMessageProviderFixture.cs
@@ -1,0 +1,22 @@
+﻿using System.Net.Http;
+using Xunit;
+
+namespace Autofac.Integration.WebApi.Test
+{
+    public class AutofacHttpRequestMessageProviderFixture
+    {
+        [Fact]
+        public void SetCurrentReturnsExpectedHttpRequestMessageInGet()
+        {
+            // Arrange
+            var httpRequestMessage = new HttpRequestMessage();
+
+            // Act
+            AutofacHttpRequestMessageProvider.Current = httpRequestMessage;
+            var result = AutofacHttpRequestMessageProvider.Current;
+
+            // Assert
+            Assert.Same(httpRequestMessage, result);
+        }
+    }
+}

--- a/test/Autofac.Integration.WebApi.Test/CurrentRequestHandlerFixture.cs
+++ b/test/Autofac.Integration.WebApi.Test/CurrentRequestHandlerFixture.cs
@@ -1,6 +1,4 @@
 ﻿using System.Net.Http;
-using System.Web.Http.Hosting;
-using Autofac.Core.Lifetime;
 using Xunit;
 
 namespace Autofac.Integration.WebApi.Test
@@ -8,16 +6,17 @@ namespace Autofac.Integration.WebApi.Test
     public class CurrentRequestHandlerFixture
     {
         [Fact]
-        public void HandlerUpdatesDependencyScopeWithHttpRequestMessage()
+        public void HandlerSetsHttpRequestMessageToProvider()
         {
+            // Arrange
             var request = new HttpRequestMessage();
-            var lifetimeScope = new ContainerBuilder().Build().BeginLifetimeScope(MatchingScopeLifetimeTags.RequestLifetimeScopeTag);
-            var scope = new AutofacWebApiDependencyScope(lifetimeScope);
-            request.Properties.Add(HttpPropertyKeys.DependencyScope, scope);
 
+            // Act
             CurrentRequestHandler.UpdateScopeWithHttpRequestMessage(request);
+            var result = AutofacHttpRequestMessageProvider.Current;
 
-            Assert.Equal(request, scope.GetService(typeof(HttpRequestMessage)));
+            // Assert
+            Assert.Equal(request, result);
         }
     }
 }

--- a/test/Autofac.Integration.WebApi.Test/HttpConfigurationExtensionsFixture.cs
+++ b/test/Autofac.Integration.WebApi.Test/HttpConfigurationExtensionsFixture.cs
@@ -59,5 +59,15 @@ namespace Autofac.Integration.WebApi.Test
 
             Assert.Equal("config", exception.ParamName);
         }
+
+        [Fact]
+        public void RegisterHttpRequestMessageTurnsOnHttpRequestMessageTracking()
+        {
+            var config = new HttpConfiguration();
+
+            config.RegisterHttpRequestMessage();
+
+            Assert.True(HttpConfigurationExtensions.IsHttpRequestMessageTrackingEnabled);
+        }
     }
 }

--- a/test/Autofac.Integration.WebApi.Test/HttpConfigurationExtensionsFixture.cs
+++ b/test/Autofac.Integration.WebApi.Test/HttpConfigurationExtensionsFixture.cs
@@ -61,14 +61,6 @@ namespace Autofac.Integration.WebApi.Test
 			Assert.Equal("config", exception.ParamName);
 		}
 
-	    [Fact]
-	    public void IsHttpRequestMessageTrackingEnabledReturnsFalseInitially()
-	    {
-	        var result = HttpConfigurationExtensions.IsHttpRequestMessageTrackingEnabled;
-
-            Assert.False(result);
-	    }
-
 		[Fact]
 		public void RegisterHttpRequestMessageTurnsOnHttpRequestMessageTracking()
 		{
@@ -92,6 +84,8 @@ namespace Autofac.Integration.WebApi.Test
 	    [Fact]
 	    public void GetHttpRequestMessageThrowsWhenIsHttpRequestMessageTrackingIsNotEnabled()
 	    {
+	        HttpConfigurationExtensions.IsHttpRequestMessageTrackingEnabled = false;
+
 	        var componentContext = new TestComponentContext();
 
 	        Assert.Throws<InvalidOperationException>(() => componentContext.GetHttpRequestMessage());

--- a/test/Autofac.Integration.WebApi.Test/HttpConfigurationExtensionsFixture.cs
+++ b/test/Autofac.Integration.WebApi.Test/HttpConfigurationExtensionsFixture.cs
@@ -31,84 +31,84 @@ using Xunit;
 
 namespace Autofac.Integration.WebApi.Test
 {
-	public class HttpConfigurationExtensionsFixture
-	{
-		[Fact]
-		public void RegisterHttpRequestMessageAddsHandler()
-		{
-			var config = new HttpConfiguration();
-			config.RegisterHttpRequestMessage();
-
-			Assert.Equal(1, config.MessageHandlers.OfType<CurrentRequestHandler>().Count());
-		}
-
-		[Fact]
-		public void RegisterHttpRequestMessageEnsuresHandlerAddedOnlyOnce()
-		{
-			var config = new HttpConfiguration();
-
-			config.RegisterHttpRequestMessage();
-			config.RegisterHttpRequestMessage();
-
-			Assert.Equal(1, config.MessageHandlers.OfType<CurrentRequestHandler>().Count());
-		}
-
-		[Fact]
-		public void RegisterHttpRequestMessageThrowsGivenNullConfig()
-		{
-			var exception = Assert.Throws<ArgumentNullException>(() => HttpConfigurationExtensions.RegisterHttpRequestMessage(null));
-
-			Assert.Equal("config", exception.ParamName);
-		}
-
-		[Fact]
-		public void RegisterHttpRequestMessageTurnsOnHttpRequestMessageTracking()
-		{
-			var config = new HttpConfiguration();
-
-			config.RegisterHttpRequestMessage();
-
-			Assert.True(HttpConfigurationExtensions.IsHttpRequestMessageTrackingEnabled);
-		}
-
-	    [Fact]
-	    public void GetHttpRequestMessageThrowsWhenComponentContextIsNull()
-	    {
-	        const IComponentContext nullContext = null;
-
-	        var exception = Assert.Throws<ArgumentNullException>(() => nullContext.GetHttpRequestMessage());
-
-            Assert.Equal("componentContext", exception.ParamName);
-	    }
-
-	    [Fact]
-	    public void GetHttpRequestMessageThrowsWhenIsHttpRequestMessageTrackingIsNotEnabled()
-	    {
-	        HttpConfigurationExtensions.IsHttpRequestMessageTrackingEnabled = false;
-
-	        var componentContext = new TestComponentContext();
-
-	        Assert.Throws<InvalidOperationException>(() => componentContext.GetHttpRequestMessage());
-	    }
-
-	    [Fact]
-	    public void GetHttpRequestMessageReturnsExpectedHttpRequestMessageWhenIsHttpRequestMessageTrackingIsEnabled()
-	    {
-            // Arrange
-	        var config = new HttpConfiguration();
+    public class HttpConfigurationExtensionsFixture
+    {
+        [Fact]
+        public void RegisterHttpRequestMessageAddsHandler()
+        {
+            var config = new HttpConfiguration();
             config.RegisterHttpRequestMessage();
 
-	        var httpRequestMessage = new HttpRequestMessage();
-	        AutofacHttpRequestMessageProvider.Current = httpRequestMessage;
+            Assert.Equal(1, config.MessageHandlers.OfType<CurrentRequestHandler>().Count());
+        }
+
+        [Fact]
+        public void RegisterHttpRequestMessageEnsuresHandlerAddedOnlyOnce()
+        {
+            var config = new HttpConfiguration();
+
+            config.RegisterHttpRequestMessage();
+            config.RegisterHttpRequestMessage();
+
+            Assert.Equal(1, config.MessageHandlers.OfType<CurrentRequestHandler>().Count());
+        }
+
+        [Fact]
+        public void RegisterHttpRequestMessageThrowsGivenNullConfig()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(() => HttpConfigurationExtensions.RegisterHttpRequestMessage(null));
+
+            Assert.Equal("config", exception.ParamName);
+        }
+
+        [Fact]
+        public void RegisterHttpRequestMessageTurnsOnHttpRequestMessageTracking()
+        {
+            var config = new HttpConfiguration();
+
+            config.RegisterHttpRequestMessage();
+
+            Assert.True(HttpConfigurationExtensions.IsHttpRequestMessageTrackingEnabled);
+        }
+
+        [Fact]
+        public void GetHttpRequestMessageThrowsWhenComponentContextIsNull()
+        {
+            const IComponentContext nullContext = null;
+
+            var exception = Assert.Throws<ArgumentNullException>(() => nullContext.GetHttpRequestMessage());
+
+            Assert.Equal("componentContext", exception.ParamName);
+        }
+
+        [Fact]
+        public void GetHttpRequestMessageThrowsWhenIsHttpRequestMessageTrackingIsNotEnabled()
+        {
+            HttpConfigurationExtensions.IsHttpRequestMessageTrackingEnabled = false;
+
+            var componentContext = new TestComponentContext();
+
+            Assert.Throws<InvalidOperationException>(() => componentContext.GetHttpRequestMessage());
+        }
+
+        [Fact]
+        public void GetHttpRequestMessageReturnsExpectedHttpRequestMessageWhenIsHttpRequestMessageTrackingIsEnabled()
+        {
+            // Arrange
+            var config = new HttpConfiguration();
+            config.RegisterHttpRequestMessage();
+
+            var httpRequestMessage = new HttpRequestMessage();
+            AutofacHttpRequestMessageProvider.Current = httpRequestMessage;
 
             var componentContext = new TestComponentContext();
 
             // Act
-	        var result = componentContext.GetHttpRequestMessage();
+            var result = componentContext.GetHttpRequestMessage();
 
             // Assert
             Assert.Same(httpRequestMessage, result);
-	    }
+        }
 
     }
 }

--- a/test/Autofac.Integration.WebApi.Test/HttpConfigurationExtensionsFixture.cs
+++ b/test/Autofac.Integration.WebApi.Test/HttpConfigurationExtensionsFixture.cs
@@ -25,6 +25,7 @@
 
 using System;
 using System.Linq;
+using System.Net.Http;
 using System.Web.Http;
 using Xunit;
 
@@ -77,5 +78,43 @@ namespace Autofac.Integration.WebApi.Test
 
 			Assert.True(HttpConfigurationExtensions.IsHttpRequestMessageTrackingEnabled);
 		}
-	}
+
+	    [Fact]
+	    public void GetHttpRequestMessageThrowsWhenComponentContextIsNull()
+	    {
+	        const IComponentContext nullContext = null;
+
+	        var exception = Assert.Throws<ArgumentNullException>(() => nullContext.GetHttpRequestMessage());
+
+            Assert.Equal("componentContext", exception.ParamName);
+	    }
+
+	    [Fact]
+	    public void GetHttpRequestMessageThrowsWhenIsHttpRequestMessageTrackingIsNotEnabled()
+	    {
+	        var componentContext = new TestComponentContext();
+
+	        Assert.Throws<InvalidOperationException>(() => componentContext.GetHttpRequestMessage());
+	    }
+
+	    [Fact]
+	    public void GetHttpRequestMessageReturnsExpectedHttpRequestMessageWhenIsHttpRequestMessageTrackingIsEnabled()
+	    {
+            // Arrange
+	        var config = new HttpConfiguration();
+            config.RegisterHttpRequestMessage();
+
+	        var httpRequestMessage = new HttpRequestMessage();
+	        AutofacHttpRequestMessageProvider.Current = httpRequestMessage;
+
+            var componentContext = new TestComponentContext();
+
+            // Act
+	        var result = componentContext.GetHttpRequestMessage();
+
+            // Assert
+            Assert.Same(httpRequestMessage, result);
+	    }
+
+    }
 }

--- a/test/Autofac.Integration.WebApi.Test/HttpConfigurationExtensionsFixture.cs
+++ b/test/Autofac.Integration.WebApi.Test/HttpConfigurationExtensionsFixture.cs
@@ -30,44 +30,52 @@ using Xunit;
 
 namespace Autofac.Integration.WebApi.Test
 {
-    public class HttpConfigurationExtensionsFixture
-    {
-        [Fact]
-        public void RegisterHttpRequestMessageAddsHandler()
-        {
-            var config = new HttpConfiguration();
-            config.RegisterHttpRequestMessage();
+	public class HttpConfigurationExtensionsFixture
+	{
+		[Fact]
+		public void RegisterHttpRequestMessageAddsHandler()
+		{
+			var config = new HttpConfiguration();
+			config.RegisterHttpRequestMessage();
 
-            Assert.Equal(1, config.MessageHandlers.OfType<CurrentRequestHandler>().Count());
-        }
+			Assert.Equal(1, config.MessageHandlers.OfType<CurrentRequestHandler>().Count());
+		}
 
-        [Fact]
-        public void RegisterHttpRequestMessageEnsuresHandlerAddedOnlyOnce()
-        {
-            var config = new HttpConfiguration();
+		[Fact]
+		public void RegisterHttpRequestMessageEnsuresHandlerAddedOnlyOnce()
+		{
+			var config = new HttpConfiguration();
 
-            config.RegisterHttpRequestMessage();
-            config.RegisterHttpRequestMessage();
+			config.RegisterHttpRequestMessage();
+			config.RegisterHttpRequestMessage();
 
-            Assert.Equal(1, config.MessageHandlers.OfType<CurrentRequestHandler>().Count());
-        }
+			Assert.Equal(1, config.MessageHandlers.OfType<CurrentRequestHandler>().Count());
+		}
 
-        [Fact]
-        public void RegisterHttpRequestMessageThrowsGivenNullConfig()
-        {
-            var exception = Assert.Throws<ArgumentNullException>(() => HttpConfigurationExtensions.RegisterHttpRequestMessage(null));
+		[Fact]
+		public void RegisterHttpRequestMessageThrowsGivenNullConfig()
+		{
+			var exception = Assert.Throws<ArgumentNullException>(() => HttpConfigurationExtensions.RegisterHttpRequestMessage(null));
 
-            Assert.Equal("config", exception.ParamName);
-        }
+			Assert.Equal("config", exception.ParamName);
+		}
 
-        [Fact]
-        public void RegisterHttpRequestMessageTurnsOnHttpRequestMessageTracking()
-        {
-            var config = new HttpConfiguration();
+	    [Fact]
+	    public void IsHttpRequestMessageTrackingEnabledReturnsFalseInitially()
+	    {
+	        var result = HttpConfigurationExtensions.IsHttpRequestMessageTrackingEnabled;
 
-            config.RegisterHttpRequestMessage();
+            Assert.False(result);
+	    }
 
-            Assert.True(HttpConfigurationExtensions.IsHttpRequestMessageTrackingEnabled);
-        }
-    }
+		[Fact]
+		public void RegisterHttpRequestMessageTurnsOnHttpRequestMessageTracking()
+		{
+			var config = new HttpConfiguration();
+
+			config.RegisterHttpRequestMessage();
+
+			Assert.True(HttpConfigurationExtensions.IsHttpRequestMessageTrackingEnabled);
+		}
+	}
 }

--- a/test/Autofac.Integration.WebApi.Test/TestTypes.cs
+++ b/test/Autofac.Integration.WebApi.Test/TestTypes.cs
@@ -32,6 +32,7 @@ using System.Web.Http;
 using System.Web.Http.Controllers;
 using System.Web.Http.Filters;
 using System.Web.Http.ModelBinding;
+using Autofac.Core;
 
 namespace Autofac.Integration.WebApi.Test
 {
@@ -320,5 +321,15 @@ namespace Autofac.Integration.WebApi.Test
         {
             return Task.FromResult(0);
         }
+    }
+
+    public class TestComponentContext : IComponentContext
+    {
+        public object ResolveComponent(IComponentRegistration registration, IEnumerable<Parameter> parameters)
+        {
+            return null;
+        }
+
+        public IComponentRegistry ComponentRegistry { get; } = null;
     }
 }


### PR DESCRIPTION
This PR tries to resolve #28.

It tries to prevent the call to `containerBuilder.Update` which is marked as obsolete as the container should be considered immutable.

The changes made are adopted from Simple Injector’s solution using a provider (https://github.com/simpleinjector/SimpleInjector/blob/master/src/SimpleInjector.Integration.WebApi/SimpleInjectorHttpRequestMessageProvider.cs)

However, adopting this solution means there will be a breaking change to users. Autofac users will be expected to implement an accessor themselves to retrieve the current `HttpRequestMessage` like:

```c#
public interface IHttpRequestMessageAcccessor
{
    HttpRequestMessage Current { get; }
}

public class AutofacHttpRequestMessageAccessor : IHttpRequestMessageAccessor
{
    private readonly IComponentContext _componentContext;

    public AutofacHttpRequestMessageAccessor(IComponentContext componentContext)
        =>  _componentContext = componentContext;

    public HttpRequestMessage Current => _componentContext.GetHttpRequestMessage();
}

// At application startup
public static class CompositionRoot
{
    public static void ReigsterDependencies()
    {
        var containerBuidler = new ContainerBuilder();
        containerBuilder.RegisterHttpRequestMessage(GlobalConfiguration.Configuration);
        containerBuidler
            .RegisterType<AutofacHttpRequestMessageAccessor>()
            .As<IHttpRequestMessageAccessor>()
            .InstancePerRequest();
        containerBuilder
            .Register(c => c.Resolve<IHttpRequestMessageAccessor>().Current)
            .As<HttpRequestMessage>()
            .InstancePerRequest();
    }
}
```
More details can be found in [Simple Injector’s documentation](http://simpleinjector.readthedocs.io/en/latest/webapiintegration.html#getting-the-current-request-s-httprequestmessage)