### PR TITLE
Fix for issue #30 - Do not execute filters after a response has been set

### DIFF
--- a/test/Autofac.Integration.WebApi.Test/ActionFilterWrapperFixture.cs
+++ b/test/Autofac.Integration.WebApi.Test/ActionFilterWrapperFixture.cs
@@ -102,6 +102,62 @@ namespace Autofac.Integration.WebApi.Test
             Assert.Equal("TestActionFilter2.OnActionExecutedAsync", order[3]);
         }
 
+        [Fact]
+        public async void StopsIfFilterOnExecutingSetsResponse()
+        {
+            // Issue #30.
+            // The filter behaviour if a response is set should be as follows, to
+            // mirror the functionality of filters in the normal IActionFilter implementations.
+            //
+            // If a filter sets the response:
+            // - OnActionExecutingAsync from subsequent calls should not be invoked.
+            // - Its own OnActionExecutedAsync should not be invoked.
+            // - OnActionExecutedAsync for prior filters should still be invoked.
+            var builder = new ContainerBuilder();
+            var order = new List<string>();
+
+            builder.Register(ctx => new DelegatingLogger(s => order.Add(s)))
+                .As<ILogger>()
+                .SingleInstance();
+            builder.RegisterType<TestActionFilter>()
+                .AsWebApiActionFilterFor<TestController>(c => c.Get())
+                .InstancePerRequest();
+            builder.RegisterType<TestActionFilterWithResponse>()
+                .AsWebApiActionFilterFor<TestController>(c => c.Get())
+                .InstancePerRequest();
+            builder.RegisterType<TestActionFilter2>()
+                .AsWebApiActionFilterFor<TestController>(c => c.Get())
+                .InstancePerRequest();
+            builder.RegisterType<TestActionFilter3>()
+                .AsWebApiActionFilterFor<TestController>(c => c.Get())
+                .InstancePerRequest();
+
+            var container = builder.Build();
+
+            var resolver = new AutofacWebApiDependencyResolver(container);
+            var controllerContext = CreateControllerContext(resolver);
+            var methodInfo = typeof(TestController).GetMethod("Get");
+            var actionDescriptor = CreateActionDescriptor(methodInfo);
+            var actionContext = new HttpActionContext(controllerContext, actionDescriptor);
+            var httpActionExecutedContext = new HttpActionExecutedContext(actionContext, null);
+            var metadata = new FilterMetadata
+            {
+                ControllerType = typeof(TestController),
+                FilterScope = FilterScope.Action,
+                MethodInfo = methodInfo
+            };
+            var wrapper = new ActionFilterWrapper(metadata);
+
+            await wrapper.OnActionExecutingAsync(actionContext, CancellationToken.None);
+
+            Assert.Equal("TestActionFilter3.OnActionExecutingAsync", order[0]);
+            Assert.Equal("TestActionFilter2.OnActionExecutingAsync", order[1]);
+            Assert.Equal("TestActionFilterWithResponse.OnActionExecutingAsync", order[2]);
+            Assert.Equal("TestActionFilter2.OnActionExecutedAsync", order[3]);
+            Assert.Equal("TestActionFilter3.OnActionExecutedAsync", order[4]);
+            Assert.Equal(5, order.Count);
+        }
+
         private static HttpActionDescriptor CreateActionDescriptor(MethodInfo methodInfo)
         {
             var controllerDescriptor = new HttpControllerDescriptor { ControllerType = methodInfo.DeclaringType };

--- a/test/Autofac.Integration.WebApi.Test/Autofac.Integration.WebApi.Test.csproj
+++ b/test/Autofac.Integration.WebApi.Test/Autofac.Integration.WebApi.Test.csproj
@@ -91,6 +91,8 @@
     <Compile Include="TestTypes\InterfaceController.cs" />
     <Compile Include="TestTypes\IsAControllerNot.cs" />
     <Compile Include="TestTypes\Logger.cs" />
+    <Compile Include="TestTypes\TestActionFilter3.cs" />
+    <Compile Include="TestTypes\TestActionFilterWithResponse.cs" />
     <Compile Include="TestTypes\TestActionFilter.cs" />
     <Compile Include="TestTypes\TestActionFilter2.cs" />
     <Compile Include="TestTypes\TestAuthenticationFilter.cs" />

--- a/test/Autofac.Integration.WebApi.Test/TestTypes/TestActionFilter3.cs
+++ b/test/Autofac.Integration.WebApi.Test/TestTypes/TestActionFilter3.cs
@@ -1,0 +1,54 @@
+﻿// This software is part of the Autofac IoC container
+// Copyright (c) 2012 Autofac Contributors
+// https://autofac.org
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web.Http.Controllers;
+using System.Web.Http.Filters;
+
+namespace Autofac.Integration.WebApi.Test.TestTypes
+{
+    public class TestActionFilter3 : IAutofacActionFilter
+    {
+        public ILogger Logger { get; private set; }
+
+        public TestActionFilter3(ILogger logger)
+        {
+            Logger = logger;
+        }
+
+        public Task OnActionExecutingAsync(HttpActionContext actionContext, CancellationToken cancellationToken)
+        {
+            this.Logger.Log("TestActionFilter3.OnActionExecutingAsync");
+            return Task.FromResult(0);
+        }
+
+        public Task OnActionExecutedAsync(HttpActionExecutedContext actionExecutedContext, CancellationToken cancellationToken)
+        {
+            this.Logger.Log("TestActionFilter3.OnActionExecutedAsync");
+            return Task.FromResult(0);
+        }
+    }
+}

--- a/test/Autofac.Integration.WebApi.Test/TestTypes/TestActionFilterWithResponse.cs
+++ b/test/Autofac.Integration.WebApi.Test/TestTypes/TestActionFilterWithResponse.cs
@@ -1,0 +1,61 @@
+﻿// This software is part of the Autofac IoC container
+// Copyright (c) 2012 Autofac Contributors
+// https://autofac.org
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web.Http;
+using System.Web.Http.Controllers;
+using System.Web.Http.Filters;
+using System.Web.Http.ModelBinding;
+
+namespace Autofac.Integration.WebApi.Test.TestTypes
+{
+    public class TestActionFilterWithResponse : IAutofacActionFilter
+    {
+        public ILogger Logger { get; private set; }
+
+        public TestActionFilterWithResponse(ILogger logger)
+        {
+            Logger = logger;
+        }
+
+        public Task OnActionExecutingAsync(HttpActionContext actionContext, CancellationToken cancellationToken)
+        {
+            this.Logger.Log("TestActionFilterWithResponse.OnActionExecutingAsync");
+            actionContext.Response = actionContext.Request.CreateErrorResponse(HttpStatusCode.Forbidden, "forbidden");
+            return Task.FromResult(0);
+        }
+
+        public Task OnActionExecutedAsync(HttpActionExecutedContext actionExecutedContext, CancellationToken cancellationToken)
+        {
+            this.Logger.Log("TestActionFilterWithResponse.OnActionExecutedAsync");
+            return Task.FromResult(0);
+        }
+    }
+}


### PR DESCRIPTION
This turned out to be slightly more complicated than I expected because in order to match the behaviour of normal WebAPI filters I had to walk back through the already-executed filters and manually invoke OnActionExecutedAsync for each.

To do this I had to allocate a list to hold the executed filters; I couldn't think of a more efficient way to walk backwards from the position in the filter enumerable I had reached.

I'll raise a related pull request for a documentation update shortly.