### PR TITLE
Filter registration overhaul to use predicates

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
-  package_semantic_version: 4.2.1
-  assembly_semantic_version: 4.2.1
+  package_semantic_version: 4.3.0
+  assembly_semantic_version: 4.3.0
 
 version: $(package_semantic_version).{build}
 

--- a/src/Autofac.Integration.WebApi/ActionFilterOverrideWrapper.cs
+++ b/src/Autofac.Integration.WebApi/ActionFilterOverrideWrapper.cs
@@ -24,6 +24,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.Collections.Generic;
 using System.Web.Http.Filters;
 
 namespace Autofac.Integration.WebApi
@@ -38,17 +39,9 @@ namespace Autofac.Integration.WebApi
         /// Initializes a new instance of the <see cref="ActionFilterOverrideWrapper"/> class.
         /// </summary>
         /// <param name="filterMetadata">The filter metadata.</param>
-        public ActionFilterOverrideWrapper(FilterMetadata filterMetadata)
+        public ActionFilterOverrideWrapper(HashSet<FilterMetadata> filterMetadata)
             : base(filterMetadata)
         {
-        }
-
-        /// <summary>
-        /// Gets the metadata key used to retrieve the filter metadata.
-        /// </summary>
-        public override string MetadataKey
-        {
-            get { return AutofacWebApiFilterProvider.ActionFilterOverrideMetadataKey; }
         }
 
         /// <summary>

--- a/src/Autofac.Integration.WebApi/ActionFilterWrapper.cs
+++ b/src/Autofac.Integration.WebApi/ActionFilterWrapper.cs
@@ -41,30 +41,22 @@ namespace Autofac.Integration.WebApi
     /// </summary>
     [SuppressMessage("Microsoft.Performance", "CA1813:AvoidUnsealedAttributes", Justification = "Derived attribute adds filter override support")]
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, Inherited = true, AllowMultiple = true)]
-    internal class ActionFilterWrapper : ActionFilterAttribute, IAutofacActionFilter, IFilterWrapper
+    internal class ActionFilterWrapper : ActionFilterAttribute, IAutofacActionFilter
     {
-        private readonly FilterMetadata _filterMetadata;
+        private readonly HashSet<FilterMetadata> _allFilters;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ActionFilterWrapper"/> class.
         /// </summary>
-        /// <param name="filterMetadata">The filter metadata.</param>
-        public ActionFilterWrapper(FilterMetadata filterMetadata)
+        /// <param name="filterMetadata">The collection of filter metadata blocks that this wrapper should run.</param>
+        public ActionFilterWrapper(HashSet<FilterMetadata> filterMetadata)
         {
             if (filterMetadata == null)
             {
                 throw new ArgumentNullException(nameof(filterMetadata));
             }
 
-            this._filterMetadata = filterMetadata;
-        }
-
-        /// <summary>
-        /// Gets the metadata key used to retrieve the filter metadata.
-        /// </summary>
-        public virtual string MetadataKey
-        {
-            get { return AutofacWebApiFilterProvider.ActionFilterMetadataKey; }
+            _allFilters = filterMetadata;
         }
 
         /// <summary>
@@ -167,14 +159,11 @@ namespace Autofac.Integration.WebApi
 
         private bool FilterMatchesMetadata(Meta<Lazy<IAutofacActionFilter>> filter)
         {
-            var metadata = filter.Metadata.TryGetValue(this.MetadataKey, out var metadataAsObject)
+            var metadata = filter.Metadata.TryGetValue(AutofacWebApiFilterProvider.FilterMetadataKey, out var metadataAsObject)
                 ? metadataAsObject as FilterMetadata
                 : null;
 
-            return metadata != null
-                && metadata.ControllerType == this._filterMetadata.ControllerType
-                && metadata.FilterScope == this._filterMetadata.FilterScope
-                && metadata.MethodInfo == this._filterMetadata.MethodInfo;
+            return _allFilters.Contains(metadata);
         }
     }
 }

--- a/src/Autofac.Integration.WebApi/AuthenticationFilterOverrideWrapper.cs
+++ b/src/Autofac.Integration.WebApi/AuthenticationFilterOverrideWrapper.cs
@@ -24,6 +24,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.Collections.Generic;
 using System.Web.Http.Filters;
 
 namespace Autofac.Integration.WebApi
@@ -37,17 +38,9 @@ namespace Autofac.Integration.WebApi
         /// Initializes a new instance of the <see cref="AuthenticationFilterOverrideWrapper"/> class.
         /// </summary>
         /// <param name="filterMetadata">The filter metadata.</param>
-        public AuthenticationFilterOverrideWrapper(FilterMetadata filterMetadata)
+        public AuthenticationFilterOverrideWrapper(HashSet<FilterMetadata> filterMetadata)
             : base(filterMetadata)
         {
-        }
-
-        /// <summary>
-        /// Gets the metadata key used to retrieve the filter metadata.
-        /// </summary>
-        public override string MetadataKey
-        {
-            get { return AutofacWebApiFilterProvider.AuthenticationFilterOverrideMetadataKey; }
         }
 
         /// <summary>

--- a/src/Autofac.Integration.WebApi/AuthenticationFilterWrapper.cs
+++ b/src/Autofac.Integration.WebApi/AuthenticationFilterWrapper.cs
@@ -37,30 +37,22 @@ namespace Autofac.Integration.WebApi
     /// <summary>
     /// Resolves a filter for the specified metadata for each controller request.
     /// </summary>
-    internal class AuthenticationFilterWrapper : IAuthenticationFilter, IAutofacAuthenticationFilter, IFilterWrapper
+    internal class AuthenticationFilterWrapper : IAuthenticationFilter, IAutofacAuthenticationFilter
     {
-        private readonly FilterMetadata _filterMetadata;
+        private readonly HashSet<FilterMetadata> _allFilters;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AuthenticationFilterWrapper"/> class.
         /// </summary>
         /// <param name="filterMetadata">The filter metadata.</param>
-        public AuthenticationFilterWrapper(FilterMetadata filterMetadata)
+        public AuthenticationFilterWrapper(HashSet<FilterMetadata> filterMetadata)
         {
             if (filterMetadata == null)
             {
                 throw new ArgumentNullException(nameof(filterMetadata));
             }
 
-            this._filterMetadata = filterMetadata;
-        }
-
-        /// <summary>
-        /// Gets the metadata key used to retrieve the filter metadata.
-        /// </summary>
-        public virtual string MetadataKey
-        {
-            get { return AutofacWebApiFilterProvider.AuthenticationFilterMetadataKey; }
+            _allFilters = filterMetadata;
         }
 
         bool IFilter.AllowMultiple
@@ -106,14 +98,11 @@ namespace Autofac.Integration.WebApi
 
         private bool FilterMatchesMetadata(Meta<Lazy<IAutofacAuthenticationFilter>> filter)
         {
-            var metadata = filter.Metadata.TryGetValue(this.MetadataKey, out var metadataAsObject)
+            var metadata = filter.Metadata.TryGetValue(AutofacWebApiFilterProvider.FilterMetadataKey, out var metadataAsObject)
                 ? metadataAsObject as FilterMetadata
                 : null;
 
-            return metadata != null
-                   && metadata.ControllerType == this._filterMetadata.ControllerType
-                   && metadata.FilterScope == this._filterMetadata.FilterScope
-                   && metadata.MethodInfo == this._filterMetadata.MethodInfo;
+            return _allFilters.Contains(metadata);
         }
     }
 }

--- a/src/Autofac.Integration.WebApi/AuthorizationFilterWrapper.cs
+++ b/src/Autofac.Integration.WebApi/AuthorizationFilterWrapper.cs
@@ -41,30 +41,22 @@ namespace Autofac.Integration.WebApi
     /// </summary>
     [SuppressMessage("Microsoft.Performance", "CA1813:AvoidUnsealedAttributes", Justification = "Derived attribute adds filter override support")]
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, Inherited = true, AllowMultiple = true)]
-    internal class AuthorizationFilterWrapper : AuthorizationFilterAttribute, IAutofacAuthorizationFilter, IFilterWrapper
+    internal class AuthorizationFilterWrapper : AuthorizationFilterAttribute, IAutofacAuthorizationFilter
     {
-        private readonly FilterMetadata _filterMetadata;
+        private readonly HashSet<FilterMetadata> _allFilters;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AuthorizationFilterWrapper"/> class.
         /// </summary>
         /// <param name="filterMetadata">The filter metadata.</param>
-        public AuthorizationFilterWrapper(FilterMetadata filterMetadata)
+        public AuthorizationFilterWrapper(HashSet<FilterMetadata> filterMetadata)
         {
             if (filterMetadata == null)
             {
                 throw new ArgumentNullException(nameof(filterMetadata));
             }
 
-            this._filterMetadata = filterMetadata;
-        }
-
-        /// <summary>
-        /// Gets the metadata key used to retrieve the filter metadata.
-        /// </summary>
-        public virtual string MetadataKey
-        {
-            get { return AutofacWebApiFilterProvider.AuthorizationFilterMetadataKey; }
+            _allFilters = filterMetadata;
         }
 
         /// <summary>
@@ -95,14 +87,11 @@ namespace Autofac.Integration.WebApi
 
         private bool FilterMatchesMetadata(Meta<Lazy<IAutofacAuthorizationFilter>> filter)
         {
-            var metadata = filter.Metadata.TryGetValue(this.MetadataKey, out var metadataAsObject)
+            var metadata = filter.Metadata.TryGetValue(AutofacWebApiFilterProvider.FilterMetadataKey, out var metadataAsObject)
                 ? metadataAsObject as FilterMetadata
                 : null;
 
-            return metadata != null
-                && metadata.ControllerType == this._filterMetadata.ControllerType
-                && metadata.FilterScope == this._filterMetadata.FilterScope
-                && metadata.MethodInfo == this._filterMetadata.MethodInfo;
+            return _allFilters.Contains(metadata);
         }
     }
 }

--- a/src/Autofac.Integration.WebApi/Autofac.Integration.WebApi.csproj
+++ b/src/Autofac.Integration.WebApi/Autofac.Integration.WebApi.csproj
@@ -54,6 +54,7 @@
     <Compile Include="ActionFilterWrapper.cs" />
     <Compile Include="AuthorizationFilterWrapper.cs" />
     <Compile Include="ActionFilterOverrideWrapper.cs" />
+    <Compile Include="AutofacFilterCategory.cs" />
     <Compile Include="AutofacOverrideFilter.cs" />
     <Compile Include="AutofacWebApiDependencyResolver.cs" />
     <Compile Include="AutofacWebApiDependencyScope.cs" />
@@ -64,6 +65,7 @@
     <Compile Include="AuthenticationFilterOverrideWrapper.cs" />
     <Compile Include="AuthorizationFilterOverrideWrapper.cs" />
     <Compile Include="ExceptionFilterOverrideWrapper.cs" />
+    <Compile Include="FilterPredicateMetadata.cs" />
     <Compile Include="HttpConfigurationExtensions.cs" />
     <Compile Include="HttpRequestMessageProvider.cs" />
     <Compile Include="IAutofacAuthenticationFilter.cs" />
@@ -80,7 +82,6 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>AutofacControllerConfigurationAttributeResources.resx</DependentUpon>
     </Compile>
-    <Compile Include="IFilterWrapper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RegistrationExtensions.cs" />
     <Compile Include="RegistrationExtensionsResources.Designer.cs">

--- a/src/Autofac.Integration.WebApi/AutofacFilterCategory.cs
+++ b/src/Autofac.Integration.WebApi/AutofacFilterCategory.cs
@@ -1,5 +1,5 @@
 ﻿// This software is part of the Autofac IoC container
-// Copyright (c) 2013 Autofac Contributors
+// Copyright © 2011 Autofac Contributors
 // https://autofac.org
 //
 // Permission is hereby granted, free of charge, to any person
@@ -23,33 +23,51 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
-using System;
-using System.Collections.Generic;
-using System.Web.Http.Filters;
-
 namespace Autofac.Integration.WebApi
 {
     /// <summary>
-    /// Resolves a filter override for the specified metadata for each controller request.
+    /// Filter categories (used for grouping/ordering filters).
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, Inherited = true, AllowMultiple = true)]
-    internal sealed class AuthorizationFilterOverrideWrapper : AuthorizationFilterWrapper, IOverrideFilter
+    internal enum AutofacFilterCategory
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="AuthorizationFilterOverrideWrapper"/> class.
+        /// Authorization Filters
         /// </summary>
-        /// <param name="filterMetadata">The filter metadata.</param>
-        public AuthorizationFilterOverrideWrapper(HashSet<FilterMetadata> filterMetadata)
-            : base(filterMetadata)
-        {
-        }
+        AuthorizationFilter,
 
         /// <summary>
-        /// Gets the filters to override.
+        /// Authorization Override Filters
         /// </summary>
-        public Type FiltersToOverride
-        {
-            get { return typeof(IAuthorizationFilter); }
-        }
+        AuthorizationFilterOverride,
+
+        /// <summary>
+        /// Authentication filters
+        /// </summary>
+        AuthenticationFilter,
+
+        /// <summary>
+        /// Authentication Override Filters
+        /// </summary>
+        AuthenticationFilterOverride,
+
+        /// <summary>
+        /// Action filters
+        /// </summary>
+        ActionFilter,
+
+        /// <summary>
+        /// Action Override filters
+        /// </summary>
+        ActionFilterOverride,
+
+        /// <summary>
+        /// Exception filters
+        /// </summary>
+        ExceptionFilter,
+
+        /// <summary>
+        /// Exception override filters
+        /// </summary>
+        ExceptionFilterOverride
     }
 }

--- a/src/Autofac.Integration.WebApi/AutofacWebApiFilterProvider.cs
+++ b/src/Autofac.Integration.WebApi/AutofacWebApiFilterProvider.cs
@@ -26,7 +26,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Web.Http;
 using System.Web.Http.Controllers;
 using System.Web.Http.Filters;
@@ -48,23 +47,13 @@ namespace Autofac.Integration.WebApi
 
             public List<FilterInfo> Filters { get; set; }
 
-            public Dictionary<string, List<FilterMetadata>> AddedFilters { get; set; }
+            public Dictionary<AutofacFilterCategory, List<FilterPredicateMetadata>> AddedFilters { get; set; }
         }
 
         private readonly ILifetimeScope _rootLifetimeScope;
         private readonly ActionDescriptorFilterProvider _filterProvider = new ActionDescriptorFilterProvider();
 
-        internal const string ActionFilterMetadataKey = "AutofacWebApiActionFilter";
-        internal const string ActionFilterOverrideMetadataKey = "AutofacWebApiActionFilterOverride";
-
-        internal const string AuthorizationFilterMetadataKey = "AutofacWebApiAuthorizationFilter";
-        internal const string AuthorizationFilterOverrideMetadataKey = "AutofacWebApiAuthorizationFilterOverride";
-
-        internal const string AuthenticationFilterMetadataKey = "AutofacWebApiAuthenticationFilter";
-        internal const string AuthenticationFilterOverrideMetadataKey = "AutofacWebApiAuthenticationFilterOverride";
-
-        internal const string ExceptionFilterMetadataKey = "AutofacWebApiExceptionFilter";
-        internal const string ExceptionFilterOverrideMetadataKey = "AutofacWebApiExceptionFilterOverride";
+        internal const string FilterMetadataKey = "AutofacFilterData";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AutofacWebApiFilterProvider"/> class.
@@ -99,9 +88,6 @@ namespace Autofac.Integration.WebApi
             foreach (var filterInfo in filters)
                 _rootLifetimeScope.InjectProperties(filterInfo.Instance);
 
-            var descriptor = actionDescriptor as ReflectedHttpActionDescriptor;
-            if (descriptor == null) return filters;
-
             // Use a fake scope to resolve the metadata for the filter.
             var rootLifetimeScope = configuration.DependencyResolver.GetRootLifetimeScope();
             using (var lifetimeScope = rootLifetimeScope.BeginLifetimeScope(MatchingScopeLifetimeTags.RequestLifetimeScopeTag))
@@ -111,228 +97,175 @@ namespace Autofac.Integration.WebApi
                     LifetimeScope = lifetimeScope,
                     ControllerType = actionDescriptor.ControllerDescriptor.ControllerType,
                     Filters = filters,
-                    AddedFilters = new Dictionary<string, List<FilterMetadata>>
+                    AddedFilters = new Dictionary<AutofacFilterCategory, List<FilterPredicateMetadata>>
                     {
-                        { ActionFilterMetadataKey, new List<FilterMetadata>() },
-                        { ActionFilterOverrideMetadataKey, new List<FilterMetadata>() },
-                        { AuthenticationFilterMetadataKey, new List<FilterMetadata>() },
-                        { AuthenticationFilterOverrideMetadataKey, new List<FilterMetadata>() },
-                        { AuthorizationFilterMetadataKey, new List<FilterMetadata>() },
-                        { AuthorizationFilterOverrideMetadataKey, new List<FilterMetadata>() },
-                        { ExceptionFilterMetadataKey, new List<FilterMetadata>() },
-                        { ExceptionFilterOverrideMetadataKey, new List<FilterMetadata>() }
+                        { AutofacFilterCategory.ActionFilter, new List<FilterPredicateMetadata>() },
+                        { AutofacFilterCategory.ActionFilterOverride, new List<FilterPredicateMetadata>() },
+                        { AutofacFilterCategory.AuthenticationFilter, new List<FilterPredicateMetadata>() },
+                        { AutofacFilterCategory.AuthenticationFilterOverride, new List<FilterPredicateMetadata>() },
+                        { AutofacFilterCategory.AuthorizationFilter, new List<FilterPredicateMetadata>() },
+                        { AutofacFilterCategory.AuthorizationFilterOverride, new List<FilterPredicateMetadata>() },
+                        { AutofacFilterCategory.ExceptionFilter, new List<FilterPredicateMetadata>() },
+                        { AutofacFilterCategory.ExceptionFilterOverride, new List<FilterPredicateMetadata>() }
                     }
                 };
 
                 // Controller scoped override filters (NOOP kind).
-                ResolveControllerScopedNoopFilterOverrides(filterContext);
+                ResolveScopedNoopFilterOverrides(filterContext, FilterScope.Controller, actionDescriptor);
 
                 // Action scoped override filters (NOOP kind).
-                ResolveActionScopedNoopFilterOverrides(filterContext, descriptor);
+                ResolveScopedNoopFilterOverrides(filterContext, FilterScope.Action, actionDescriptor);
 
                 // Controller scoped override filters.
-                ResolveControllerScopedFilterOverrides(filterContext);
+                ResolveAllScopedFilterOverrides(filterContext, FilterScope.Controller, actionDescriptor);
 
                 // Action scoped override filters.
-                ResolveActionScopedFilterOverrides(filterContext, descriptor);
+                ResolveAllScopedFilterOverrides(filterContext, FilterScope.Action, actionDescriptor);
 
                 // Controller scoped filters.
-                ResolveControllerScopedFilters(filterContext);
+                ResolveAllScopedFilters(filterContext, FilterScope.Controller, actionDescriptor);
 
                 // Action scoped filters.
-                ResolveActionScopedFilters(filterContext, descriptor);
+                ResolveAllScopedFilters(filterContext, FilterScope.Action, actionDescriptor);
             }
 
             return filters;
         }
 
-        private static void ResolveControllerScopedNoopFilterOverrides(FilterContext filterContext)
+        private static void ResolveScopedNoopFilterOverrides(FilterContext filterContext, FilterScope scope, HttpActionDescriptor descriptor)
         {
-            ResolveControllerScopedOverrideFilter(filterContext, ActionFilterOverrideMetadataKey);
-            ResolveControllerScopedOverrideFilter(filterContext, AuthenticationFilterOverrideMetadataKey);
-            ResolveControllerScopedOverrideFilter(filterContext, AuthorizationFilterOverrideMetadataKey);
-            ResolveControllerScopedOverrideFilter(filterContext, ExceptionFilterOverrideMetadataKey);
+            ResolveScopedOverrideFilter(filterContext, scope, AutofacFilterCategory.ActionFilterOverride, descriptor);
+            ResolveScopedOverrideFilter(filterContext, scope, AutofacFilterCategory.AuthenticationFilterOverride, descriptor);
+            ResolveScopedOverrideFilter(filterContext, scope, AutofacFilterCategory.AuthorizationFilterOverride, descriptor);
+            ResolveScopedOverrideFilter(filterContext, scope, AutofacFilterCategory.ExceptionFilterOverride, descriptor);
         }
 
-        private static void ResolveActionScopedNoopFilterOverrides(FilterContext filterContext, ReflectedHttpActionDescriptor descriptor)
+        private static void ResolveAllScopedFilterOverrides(FilterContext filterContext, FilterScope scope, HttpActionDescriptor descriptor)
         {
-            ResolveActionScopedOverrideFilter(filterContext, descriptor.MethodInfo, ActionFilterOverrideMetadataKey);
-            ResolveActionScopedOverrideFilter(filterContext, descriptor.MethodInfo, AuthenticationFilterOverrideMetadataKey);
-            ResolveActionScopedOverrideFilter(filterContext, descriptor.MethodInfo, AuthorizationFilterOverrideMetadataKey);
-            ResolveActionScopedOverrideFilter(filterContext, descriptor.MethodInfo, ExceptionFilterOverrideMetadataKey);
+            ResolveScopedFilter<IAutofacActionFilter, ActionFilterOverrideWrapper>(
+                filterContext, scope, descriptor, hs => new ActionFilterOverrideWrapper(hs), AutofacFilterCategory.ActionFilterOverride);
+            ResolveScopedFilter<IAutofacAuthenticationFilter, AuthenticationFilterOverrideWrapper>(
+                filterContext, scope, descriptor, hs => new AuthenticationFilterOverrideWrapper(hs), AutofacFilterCategory.AuthenticationFilterOverride);
+            ResolveScopedFilter<IAutofacAuthorizationFilter, AuthorizationFilterOverrideWrapper>(
+                filterContext, scope, descriptor, hs => new AuthorizationFilterOverrideWrapper(hs), AutofacFilterCategory.AuthorizationFilterOverride);
+            ResolveScopedFilter<IAutofacExceptionFilter, ExceptionFilterOverrideWrapper>(
+                filterContext, scope, descriptor, hs => new ExceptionFilterOverrideWrapper(hs), AutofacFilterCategory.ExceptionFilterOverride);
         }
 
-        private static void ResolveControllerScopedFilterOverrides(FilterContext filterContext)
+        private static void ResolveAllScopedFilters(FilterContext filterContext, FilterScope scope, HttpActionDescriptor descriptor)
         {
-            ResolveControllerScopedFilter<IAutofacActionFilter, ActionFilterOverrideWrapper>(
-                filterContext, m => new ActionFilterOverrideWrapper(m), ActionFilterOverrideMetadataKey);
-            ResolveControllerScopedFilter<IAutofacAuthenticationFilter, AuthenticationFilterOverrideWrapper>(
-                filterContext, m => new AuthenticationFilterOverrideWrapper(m), AuthenticationFilterOverrideMetadataKey);
-            ResolveControllerScopedFilter<IAutofacAuthorizationFilter, AuthorizationFilterOverrideWrapper>(
-                filterContext, m => new AuthorizationFilterOverrideWrapper(m), AuthorizationFilterOverrideMetadataKey);
-            ResolveControllerScopedFilter<IAutofacExceptionFilter, ExceptionFilterOverrideWrapper>(
-                filterContext, m => new ExceptionFilterOverrideWrapper(m), ExceptionFilterOverrideMetadataKey);
+            ResolveScopedFilter<IAutofacActionFilter, ActionFilterWrapper>(
+                filterContext, scope, descriptor, hs => new ActionFilterWrapper(hs), AutofacFilterCategory.ActionFilter);
+            ResolveScopedFilter<IAutofacAuthenticationFilter, AuthenticationFilterWrapper>(
+                filterContext, scope, descriptor, hs => new AuthenticationFilterWrapper(hs), AutofacFilterCategory.AuthenticationFilter);
+            ResolveScopedFilter<IAutofacAuthorizationFilter, AuthorizationFilterWrapper>(
+                filterContext, scope, descriptor, hs => new AuthorizationFilterWrapper(hs), AutofacFilterCategory.AuthorizationFilter);
+            ResolveScopedFilter<IAutofacExceptionFilter, ExceptionFilterWrapper>(
+                filterContext, scope, descriptor, hs => new ExceptionFilterWrapper(hs), AutofacFilterCategory.ExceptionFilter);
         }
 
-        private static void ResolveActionScopedFilterOverrides(FilterContext filterContext, ReflectedHttpActionDescriptor descriptor)
-        {
-            ResolveActionScopedFilter<IAutofacActionFilter, ActionFilterOverrideWrapper>(
-                filterContext, descriptor.MethodInfo, m => new ActionFilterOverrideWrapper(m), ActionFilterOverrideMetadataKey);
-            ResolveActionScopedFilter<IAutofacAuthenticationFilter, AuthenticationFilterOverrideWrapper>(
-                filterContext,
-                descriptor.MethodInfo,
-                m => new AuthenticationFilterOverrideWrapper(m),
-                AuthenticationFilterOverrideMetadataKey);
-            ResolveActionScopedFilter<IAutofacAuthorizationFilter, AuthorizationFilterOverrideWrapper>(
-                filterContext,
-                descriptor.MethodInfo,
-                m => new AuthorizationFilterOverrideWrapper(m),
-                AuthorizationFilterOverrideMetadataKey);
-            ResolveActionScopedFilter<IAutofacExceptionFilter, ExceptionFilterOverrideWrapper>(
-                filterContext,
-                descriptor.MethodInfo,
-                m => new ExceptionFilterOverrideWrapper(m),
-                ExceptionFilterOverrideMetadataKey);
-        }
-
-        private static void ResolveControllerScopedFilters(FilterContext filterContext)
-        {
-            ResolveControllerScopedFilter<IAutofacActionFilter, ActionFilterWrapper>(
-                filterContext, m => new ActionFilterWrapper(m), ActionFilterMetadataKey);
-            ResolveControllerScopedFilter<IAutofacAuthenticationFilter, AuthenticationFilterWrapper>(
-                filterContext, m => new AuthenticationFilterWrapper(m), AuthenticationFilterMetadataKey);
-            ResolveControllerScopedFilter<IAutofacAuthorizationFilter, AuthorizationFilterWrapper>(
-                filterContext, m => new AuthorizationFilterWrapper(m), AuthorizationFilterMetadataKey);
-            ResolveControllerScopedFilter<IAutofacExceptionFilter, ExceptionFilterWrapper>(
-                filterContext, m => new ExceptionFilterWrapper(m), ExceptionFilterMetadataKey);
-        }
-
-        private static void ResolveActionScopedFilters(FilterContext filterContext, ReflectedHttpActionDescriptor descriptor)
-        {
-            ResolveActionScopedFilter<IAutofacActionFilter, ActionFilterWrapper>(
-                filterContext, descriptor.MethodInfo, m => new ActionFilterWrapper(m), ActionFilterMetadataKey);
-            ResolveActionScopedFilter<IAutofacAuthenticationFilter, AuthenticationFilterWrapper>(
-                filterContext, descriptor.MethodInfo, m => new AuthenticationFilterWrapper(m), AuthenticationFilterMetadataKey);
-            ResolveActionScopedFilter<IAutofacAuthorizationFilter, AuthorizationFilterWrapper>(
-                filterContext, descriptor.MethodInfo, m => new AuthorizationFilterWrapper(m), AuthorizationFilterMetadataKey);
-            ResolveActionScopedFilter<IAutofacExceptionFilter, ExceptionFilterWrapper>(
-                filterContext, descriptor.MethodInfo, m => new ExceptionFilterWrapper(m), ExceptionFilterMetadataKey);
-        }
-
-        private static void ResolveControllerScopedFilter<TFilter, TWrapper>(
-            FilterContext filterContext, Func<FilterMetadata, TWrapper> wrapperFactory, string metadataKey)
+        private static void ResolveScopedFilter<TFilter, TWrapper>(
+            FilterContext filterContext, FilterScope scope, HttpActionDescriptor descriptor, Func<HashSet<FilterMetadata>, TWrapper> wrapperFactory, AutofacFilterCategory filterCategory)
             where TFilter : class
-            where TWrapper : IFilter
+            where TWrapper : class, IFilter
         {
             var filters = filterContext.LifetimeScope.Resolve<IEnumerable<Meta<Lazy<TFilter>>>>();
 
-            foreach (var filter in filters)
-            {
-                var metadata = filter.Metadata.TryGetValue(metadataKey, out var metadataAsObject)
-                    ? metadataAsObject as FilterMetadata
-                    : null;
-
-                if (metadata != null)
-                {
-                    if (!FilterMatchesController(filterContext, metadataKey, metadata)) continue;
-
-                    var wrapper = wrapperFactory(metadata);
-                    filterContext.Filters.Add(new FilterInfo(wrapper, metadata.FilterScope));
-                    filterContext.AddedFilters[metadataKey].Add(metadata);
-                }
-            }
-        }
-
-        private static void ResolveActionScopedFilter<TFilter, TWrapper>(
-            FilterContext filterContext, MethodInfo methodInfo, Func<FilterMetadata, TWrapper> wrapperFactory, string metadataKey)
-            where TFilter : class
-            where TWrapper : IFilter
-        {
-            var filters = filterContext.LifetimeScope.Resolve<IEnumerable<Meta<Lazy<TFilter>>>>();
+            // We'll store the unique filter registrations here until we create the wrapper.
+            HashSet<FilterMetadata> metadataSet = null;
 
             foreach (var filter in filters)
             {
-                var metadata = filter.Metadata.TryGetValue(metadataKey, out var metadataAsObject)
+                var metadata = filter.Metadata.TryGetValue(FilterMetadataKey, out var metadataAsObject)
                     ? metadataAsObject as FilterMetadata
                     : null;
 
+                // Match the filter category (action filter, authentication, the overrides, etc).
                 if (metadata != null)
                 {
-                    if (!FilterMatchesAction(filterContext, methodInfo, metadataKey, metadata)) continue;
-
-                    var wrapper = wrapperFactory(metadata);
-                    filterContext.Filters.Add(new FilterInfo(wrapper, metadata.FilterScope));
-                    filterContext.AddedFilters[metadataKey].Add(metadata);
+                    // Each individual predicate of the filter 'could' match the action descriptor.
+                    // The HashSet makes sure the same filter doesn't go in twice.
+                    foreach (var filterRegistration in metadata.PredicateSet)
+                    {
+                        if (FilterMatches(scope, filterCategory, descriptor, filterRegistration))
+                        {
+                            if (metadataSet == null)
+                            {
+                                // Don't define a hash set if something has already been registered (should just be the IOverrideFilters).
+                                if (!MatchingFilterAlreadyAdded(filterContext, filterCategory, descriptor, filterRegistration))
+                                {
+                                    metadataSet = new HashSet<FilterMetadata>();
+                                    metadataSet.Add(metadata);
+                                    filterContext.AddedFilters[filterCategory].Add(filterRegistration);
+                                }
+                            }
+                            else
+                            {
+                                metadataSet.Add(metadata);
+                            }
+                        }
+                    }
                 }
+            }
+
+            if (metadataSet != null)
+            {
+                // Declare our wrapper (telling it which filters it is responsible for)
+                var wrapper = wrapperFactory(metadataSet);
+                filterContext.Filters.Add(new FilterInfo(wrapper, scope));
             }
         }
 
-        private static void ResolveControllerScopedOverrideFilter(FilterContext filterContext, string metadataKey)
+        private static void ResolveScopedOverrideFilter(FilterContext filterContext, FilterScope scope, AutofacFilterCategory filterCategory, HttpActionDescriptor descriptor)
         {
             var filters = filterContext.LifetimeScope.Resolve<IEnumerable<Meta<IOverrideFilter>>>();
 
             foreach (var filter in filters)
             {
-                var metadata = filter.Metadata.TryGetValue(metadataKey, out var metadataAsObject)
+                var metadata = filter.Metadata.TryGetValue(FilterMetadataKey, out var metadataAsObject)
                     ? metadataAsObject as FilterMetadata
                     : null;
 
                 if (metadata != null)
                 {
-                    if (!FilterMatchesController(filterContext, metadataKey, metadata)) continue;
-
-                    filterContext.Filters.Add(new FilterInfo(filter.Value, metadata.FilterScope));
-                    filterContext.AddedFilters[metadataKey].Add(metadata);
+                    foreach (var filterRegistration in metadata.PredicateSet)
+                    {
+                        if (FilterMatchesAndNotAlreadyAdded(filterContext, scope, filterCategory, filterRegistration, descriptor))
+                        {
+                            filterContext.Filters.Add(new FilterInfo(filter.Value, scope));
+                            filterContext.AddedFilters[filterCategory].Add(filterRegistration);
+                        }
+                    }
                 }
             }
         }
 
-        private static void ResolveActionScopedOverrideFilter(FilterContext filterContext, MethodInfo methodInfo, string metadataKey)
+        private static bool MatchingFilterAlreadyAdded(FilterContext filterContext, AutofacFilterCategory filterCategory, HttpActionDescriptor descriptor, FilterPredicateMetadata metadata)
         {
-            var filters = filterContext.LifetimeScope.Resolve<IEnumerable<Meta<IOverrideFilter>>>();
-
-            foreach (var filter in filters)
-            {
-                var metadata = filter.Metadata.TryGetValue(metadataKey, out var metadataAsObject)
-                    ? metadataAsObject as FilterMetadata
-                    : null;
-
-                if (metadata != null)
-                {
-                    if (!FilterMatchesAction(filterContext, methodInfo, metadataKey, metadata)) continue;
-
-                    filterContext.Filters.Add(new FilterInfo(filter.Value, metadata.FilterScope));
-                    filterContext.AddedFilters[metadataKey].Add(metadata);
-                }
-            }
+            var filters = filterContext.AddedFilters[filterCategory];
+            return filters.Any(filter => filter.Scope == metadata.Scope &&
+                                         filter.Predicate(descriptor));
         }
 
-        private static bool MatchingFilterAdded(IEnumerable<FilterMetadata> filters, FilterMetadata metadata)
+        private static bool FilterMatches(
+            FilterScope scope,
+            AutofacFilterCategory filterCategory,
+            HttpActionDescriptor descriptor,
+            FilterPredicateMetadata metadata)
         {
-            return filters.Any(filter => filter.ControllerType == metadata.ControllerType
-                && filter.FilterScope == metadata.FilterScope
-                && filter.MethodInfo == metadata.MethodInfo);
+            return metadata.FilterCategory == filterCategory &&
+                   metadata.Scope == scope &&
+                   metadata.Predicate(descriptor);
         }
 
-        private static bool FilterMatchesController(FilterContext filterContext, string metadataKey, FilterMetadata metadata)
+        private static bool FilterMatchesAndNotAlreadyAdded(
+            FilterContext filterContext,
+            FilterScope scope,
+            AutofacFilterCategory filterCategory,
+            FilterPredicateMetadata metadata,
+            HttpActionDescriptor descriptor)
         {
-            return metadata.ControllerType != null
-                   && metadata.ControllerType.IsAssignableFrom(filterContext.ControllerType)
-                   && metadata.FilterScope == FilterScope.Controller
-                   && metadata.MethodInfo == null
-                   && !MatchingFilterAdded(filterContext.AddedFilters[metadataKey], metadata);
-        }
-
-        private static bool FilterMatchesAction(FilterContext filterContext, MethodInfo methodInfo, string metadataKey, FilterMetadata metadata)
-        {
-            // Issue #10: Comparing MethodInfo.MethodHandle rather than just MethodInfo equality
-            // because MethodInfo equality fails on a derived controller if the base class method
-            // isn't marked virtual... but MethodHandle correctly compares regardless.
-            return metadata.ControllerType != null
-                   && metadata.ControllerType.IsAssignableFrom(filterContext.ControllerType)
-                   && metadata.FilterScope == FilterScope.Action
-                   && metadata.MethodInfo.GetBaseDefinition().MethodHandle == methodInfo.GetBaseDefinition().MethodHandle
-                   && !MatchingFilterAdded(filterContext.AddedFilters[metadataKey], metadata);
+            return FilterMatches(scope, filterCategory, descriptor, metadata) && !MatchingFilterAlreadyAdded(filterContext, filterCategory, descriptor, metadata);
         }
     }
 }

--- a/src/Autofac.Integration.WebApi/ExceptionFilterOverrideWrapper.cs
+++ b/src/Autofac.Integration.WebApi/ExceptionFilterOverrideWrapper.cs
@@ -24,6 +24,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.Collections.Generic;
 using System.Web.Http.Filters;
 
 namespace Autofac.Integration.WebApi
@@ -38,17 +39,9 @@ namespace Autofac.Integration.WebApi
         /// Initializes a new instance of the <see cref="ExceptionFilterOverrideWrapper"/> class.
         /// </summary>
         /// <param name="filterMetadata">The filter metadata.</param>
-        public ExceptionFilterOverrideWrapper(FilterMetadata filterMetadata)
+        public ExceptionFilterOverrideWrapper(HashSet<FilterMetadata> filterMetadata)
             : base(filterMetadata)
         {
-        }
-
-        /// <summary>
-        /// Gets the metadata key used to retrieve the filter metadata.
-        /// </summary>
-        public override string MetadataKey
-        {
-            get { return AutofacWebApiFilterProvider.ExceptionFilterOverrideMetadataKey; }
         }
 
         /// <summary>

--- a/src/Autofac.Integration.WebApi/ExceptionFilterWrapper.cs
+++ b/src/Autofac.Integration.WebApi/ExceptionFilterWrapper.cs
@@ -40,30 +40,22 @@ namespace Autofac.Integration.WebApi
     /// </summary>
     [SuppressMessage("Microsoft.Performance", "CA1813:AvoidUnsealedAttributes", Justification = "Derived attribute adds filter override support")]
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, Inherited = true, AllowMultiple = true)]
-    internal class ExceptionFilterWrapper : ExceptionFilterAttribute, IAutofacExceptionFilter, IFilterWrapper
+    internal class ExceptionFilterWrapper : ExceptionFilterAttribute, IAutofacExceptionFilter
     {
-        private readonly FilterMetadata _filterMetadata;
+        private readonly HashSet<FilterMetadata> _allFilters;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ExceptionFilterWrapper"/> class.
         /// </summary>
         /// <param name="filterMetadata">The filter metadata.</param>
-        public ExceptionFilterWrapper(FilterMetadata filterMetadata)
+        public ExceptionFilterWrapper(HashSet<FilterMetadata> filterMetadata)
         {
             if (filterMetadata == null)
             {
                 throw new ArgumentNullException(nameof(filterMetadata));
             }
 
-            this._filterMetadata = filterMetadata;
-        }
-
-        /// <summary>
-        /// Gets the metadata key used to retrieve the filter metadata.
-        /// </summary>
-        public virtual string MetadataKey
-        {
-            get { return AutofacWebApiFilterProvider.ExceptionFilterMetadataKey; }
+            this._allFilters = filterMetadata;
         }
 
         /// <summary>
@@ -94,14 +86,11 @@ namespace Autofac.Integration.WebApi
 
         private bool FilterMatchesMetadata(Meta<Lazy<IAutofacExceptionFilter>> filter)
         {
-            var metadata = filter.Metadata.TryGetValue(this.MetadataKey, out var metadataAsObject)
+            var metadata = filter.Metadata.TryGetValue(AutofacWebApiFilterProvider.FilterMetadataKey, out var metadataAsObject)
                 ? metadataAsObject as FilterMetadata
                 : null;
 
-            return metadata != null
-                && metadata.ControllerType == this._filterMetadata.ControllerType
-                && metadata.FilterScope == this._filterMetadata.FilterScope
-                && metadata.MethodInfo == this._filterMetadata.MethodInfo;
+            return _allFilters.Contains(metadata);
         }
     }
 }

--- a/src/Autofac.Integration.WebApi/FilterMetadata.cs
+++ b/src/Autofac.Integration.WebApi/FilterMetadata.cs
@@ -24,9 +24,9 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Reflection;
-using System.Web.Http.Filters;
 
 namespace Autofac.Integration.WebApi
 {
@@ -36,21 +36,28 @@ namespace Autofac.Integration.WebApi
     internal class FilterMetadata
     {
         /// <summary>
-        /// Gets or sets the type of the controller.
+        /// Gets a unique ID for this filter registration.
         /// </summary>
-        [DefaultValue(null)]
-        public Type ControllerType { get; set; }
+        public Guid Id { get; } = Guid.NewGuid();
 
         /// <summary>
-        /// Gets or sets the filter scope.
+        /// Gets the registered set of predicates for this filter.
         /// </summary>
-        [DefaultValue(FilterScope.Global)]
-        public FilterScope FilterScope { get; set; }
+        public List<FilterPredicateMetadata> PredicateSet { get; } = new List<FilterPredicateMetadata>();
 
-        /// <summary>
-        /// Gets or sets the method info.
-        /// </summary>
-        [DefaultValue(null)]
-        public MethodInfo MethodInfo { get; set; }
+        public override int GetHashCode()
+        {
+            return Id.GetHashCode();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is FilterMetadata metadata)
+            {
+                return metadata.Id == Id;
+            }
+
+            return false;
+        }
     }
 }

--- a/src/Autofac.Integration.WebApi/FilterPredicateMetadata.cs
+++ b/src/Autofac.Integration.WebApi/FilterPredicateMetadata.cs
@@ -1,5 +1,5 @@
 ﻿// This software is part of the Autofac IoC container
-// Copyright (c) 2013 Autofac Contributors
+// Copyright © 2012 Autofac Contributors
 // https://autofac.org
 //
 // Permission is hereby granted, free of charge, to any person
@@ -24,32 +24,33 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
-using System.Collections.Generic;
+using System.Web.Http.Controllers;
 using System.Web.Http.Filters;
 
 namespace Autofac.Integration.WebApi
 {
     /// <summary>
-    /// Resolves a filter override for the specified metadata for each controller request.
+    /// Metadata block for an individual filter predicate.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, Inherited = true, AllowMultiple = true)]
-    internal sealed class AuthorizationFilterOverrideWrapper : AuthorizationFilterWrapper, IOverrideFilter
+    internal class FilterPredicateMetadata
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="AuthorizationFilterOverrideWrapper"/> class.
+        /// Gets or sets the callback that determines if a filter matches the action descriptor.
+        /// Returns true/false to include the filter or not.
         /// </summary>
-        /// <param name="filterMetadata">The filter metadata.</param>
-        public AuthorizationFilterOverrideWrapper(HashSet<FilterMetadata> filterMetadata)
-            : base(filterMetadata)
-        {
-        }
+        public Func<HttpActionDescriptor, bool> Predicate { get; set; }
 
         /// <summary>
-        /// Gets the filters to override.
+        /// Gets or sets the scope of the filter.
         /// </summary>
-        public Type FiltersToOverride
-        {
-            get { return typeof(IAuthorizationFilter); }
-        }
+        /// <remarks>
+        /// We need the scope of this filter registration so we can create the FilterInfo later.
+        /// </remarks>
+        public FilterScope Scope { get; set; }
+
+        /// <summary>
+        /// Gets or sets the filter category, used to group filters and control execution order.
+        /// </summary>
+        public AutofacFilterCategory FilterCategory { get; set; }
     }
 }

--- a/src/Autofac.Integration.WebApi/FilterPredicateMetadata.cs
+++ b/src/Autofac.Integration.WebApi/FilterPredicateMetadata.cs
@@ -38,7 +38,7 @@ namespace Autofac.Integration.WebApi
         /// Gets or sets the callback that determines if a filter matches the action descriptor.
         /// Returns true/false to include the filter or not.
         /// </summary>
-        public Func<HttpActionDescriptor, bool> Predicate { get; set; }
+        public Func<ILifetimeScope, HttpActionDescriptor, bool> Predicate { get; set; }
 
         /// <summary>
         /// Gets or sets the scope of the filter.

--- a/src/Autofac.Integration.WebApi/RegistrationExtensions.cs
+++ b/src/Autofac.Integration.WebApi/RegistrationExtensions.cs
@@ -316,7 +316,6 @@ namespace Autofac.Integration.WebApi
             return AsFilterFor<IAutofacActionFilter>(registration, AutofacFilterCategory.ActionFilter, predicate, filterScope);
         }
 
-
         /// <summary>
         /// Sets the provided registration to act as an <see cref="IAutofacActionFilter"/> override for the specified controller action.
         /// </summary>
@@ -382,7 +381,7 @@ namespace Autofac.Integration.WebApi
         /// <returns>A registration builder allowing further configuration of the component.</returns>
         public static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle>
             AsWebApiActionFilterOverrideWhere(
-                this IRegistrationBuilder<object, IConcreteActivatorData,SingleRegistrationStyle> registration,
+                this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration,
                 Func<ILifetimeScope, HttpActionDescriptor, bool> predicate,
                 FilterScope filterScope = FilterScope.Action)
         {
@@ -812,7 +811,6 @@ namespace Autofac.Integration.WebApi
         {
             return AsFilterFor<IAuthenticationFilter>(registration, AutofacFilterCategory.AuthenticationFilterOverride, predicate, filterScope);
         }
-
 
         /// <summary>
         /// Sets the provided registration to act as an <see cref="IOverrideFilter"/> for the specified controller action.

--- a/src/Autofac.Integration.WebApi/RegistrationExtensions.cs
+++ b/src/Autofac.Integration.WebApi/RegistrationExtensions.cs
@@ -24,6 +24,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
@@ -256,7 +257,7 @@ namespace Autofac.Integration.WebApi
                 Expression<Action<TController>> actionSelector)
                     where TController : IHttpController
         {
-            return AsFilterFor<IAutofacActionFilter, TController>(registration, AutofacWebApiFilterProvider.ActionFilterMetadataKey, actionSelector);
+            return AsFilterFor<IAutofacActionFilter, TController>(registration, AutofacFilterCategory.ActionFilter, actionSelector);
         }
 
         /// <summary>
@@ -269,7 +270,34 @@ namespace Autofac.Integration.WebApi
             AsWebApiActionFilterFor<TController>(this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration)
                 where TController : IHttpController
         {
-            return AsFilterFor<IAutofacActionFilter, TController>(registration, AutofacWebApiFilterProvider.ActionFilterMetadataKey);
+            return AsFilterFor<IAutofacActionFilter, TController>(registration, AutofacFilterCategory.ActionFilter);
+        }
+
+        /// <summary>
+        /// Sets the provided registration to act as an <see cref="IAutofacActionFilter"/> for all controllers.
+        /// </summary>
+        /// <param name="registration">The registration.</param>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        public static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle>
+            AsWebApiActionFilterForAllControllers(this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration)
+        {
+            return AsFilterFor<IAutofacActionFilter>(registration, AutofacFilterCategory.ActionFilter, descriptor => true, FilterScope.Controller);
+        }
+
+        /// <summary>
+        /// Sets the provided registration to act as an <see cref="IAutofacActionFilter"/>, based on a predicate that filters which actions it is applied to.
+        /// </summary>
+        /// <param name="registration">The registration.</param>
+        /// <param name="predicate">A predicate that should return true if this filter should be applied to the specified action.</param>
+        /// <param name="scope">The scope to apply the filter at (only Controller and Action supported).</param>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        public static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle>
+            AsWebApiActionFilterWhere(
+                this IRegistrationBuilder<object, IConcreteActivatorData,
+                SingleRegistrationStyle> registration, Func<HttpActionDescriptor, bool> predicate,
+                FilterScope scope = FilterScope.Action)
+        {
+            return AsFilterFor<IAutofacActionFilter>(registration, AutofacFilterCategory.ActionFilter, predicate, scope);
         }
 
         /// <summary>
@@ -285,7 +313,7 @@ namespace Autofac.Integration.WebApi
                 Expression<Action<TController>> actionSelector)
                     where TController : IHttpController
         {
-            return AsFilterFor<IAutofacActionFilter, TController>(registration, AutofacWebApiFilterProvider.ActionFilterOverrideMetadataKey, actionSelector);
+            return AsFilterFor<IAutofacActionFilter, TController>(registration, AutofacFilterCategory.ActionFilterOverride, actionSelector);
         }
 
         /// <summary>
@@ -298,7 +326,34 @@ namespace Autofac.Integration.WebApi
             AsWebApiActionFilterOverrideFor<TController>(this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration)
                 where TController : IHttpController
         {
-            return AsFilterFor<IAutofacActionFilter, TController>(registration, AutofacWebApiFilterProvider.ActionFilterOverrideMetadataKey);
+            return AsFilterFor<IAutofacActionFilter, TController>(registration, AutofacFilterCategory.ActionFilterOverride);
+        }
+
+        /// <summary>
+        /// Sets the provided registration to act as an <see cref="IAutofacActionFilter"/> override for all controllers.
+        /// </summary>
+        /// <param name="registration">The registration.</param>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        public static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle>
+            AsWebApiActionFilterOverrideForAllControllers(this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration)
+        {
+            return AsFilterFor<IAutofacActionFilter>(registration, AutofacFilterCategory.ActionFilterOverride, descriptor => true, FilterScope.Controller);
+        }
+
+        /// <summary>
+        /// Sets the provided registration to act as an <see cref="IAutofacActionFilter"/> override, based on a predicate that filters which actions it is applied to.
+        /// </summary>
+        /// <param name="registration">The registration.</param>
+        /// <param name="predicate">A predicate that should return true if this filter should be applied to the specified action.</param>
+        /// <param name="scope">The scope to apply the filter at (only Controller and Action supported).</param>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        public static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle>
+            AsWebApiActionFilterOverrideWhere(
+                this IRegistrationBuilder<object, IConcreteActivatorData,
+                    SingleRegistrationStyle> registration, Func<HttpActionDescriptor, bool> predicate,
+                FilterScope scope = FilterScope.Action)
+        {
+            return AsFilterFor<IAutofacActionFilter>(registration, AutofacFilterCategory.ActionFilterOverride, predicate, scope);
         }
 
         /// <summary>
@@ -314,7 +369,7 @@ namespace Autofac.Integration.WebApi
                 Expression<Action<TController>> actionSelector)
             where TController : IHttpController
         {
-            return AsFilterFor<IAutofacAuthorizationFilter, TController>(registration, AutofacWebApiFilterProvider.AuthorizationFilterMetadataKey, actionSelector);
+            return AsFilterFor<IAutofacAuthorizationFilter, TController>(registration, AutofacFilterCategory.AuthorizationFilter, actionSelector);
         }
 
         /// <summary>
@@ -327,7 +382,34 @@ namespace Autofac.Integration.WebApi
             AsWebApiAuthorizationFilterFor<TController>(this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration)
                 where TController : IHttpController
         {
-            return AsFilterFor<IAutofacAuthorizationFilter, TController>(registration, AutofacWebApiFilterProvider.AuthorizationFilterMetadataKey);
+            return AsFilterFor<IAutofacAuthorizationFilter, TController>(registration, AutofacFilterCategory.AuthorizationFilter);
+        }
+
+        /// <summary>
+        /// Sets the provided registration to act as an <see cref="IAutofacAuthorizationFilter"/> for all controllers.
+        /// </summary>
+        /// <param name="registration">The registration.</param>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        public static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle>
+            AsWebApiAuthorizationFilterForAllControllers(this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration)
+        {
+            return AsFilterFor<IAutofacAuthorizationFilter>(registration, AutofacFilterCategory.AuthorizationFilter, descriptor => true, FilterScope.Controller);
+        }
+
+        /// <summary>
+        /// Sets the provided registration to act as an <see cref="IAutofacAuthorizationFilter"/>, based on a predicate that filters which actions it is applied to.
+        /// </summary>
+        /// <param name="registration">The registration.</param>
+        /// <param name="predicate">A predicate that should return true if this filter should be applied to the specified action.</param>
+        /// <param name="scope">The scope to apply the filter at (only Controller and Action supported).</param>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        public static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle>
+            AsWebApiAuthorizationFilterWhere(
+                this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration,
+                Func<HttpActionDescriptor, bool> predicate,
+                FilterScope scope = FilterScope.Action)
+        {
+            return AsFilterFor<IAutofacAuthorizationFilter>(registration, AutofacFilterCategory.AuthorizationFilter, predicate, scope);
         }
 
         /// <summary>
@@ -343,7 +425,7 @@ namespace Autofac.Integration.WebApi
                 Expression<Action<TController>> actionSelector)
             where TController : IHttpController
         {
-            return AsFilterFor<IAutofacAuthorizationFilter, TController>(registration, AutofacWebApiFilterProvider.AuthorizationFilterOverrideMetadataKey, actionSelector);
+            return AsFilterFor<IAutofacAuthorizationFilter, TController>(registration, AutofacFilterCategory.AuthorizationFilterOverride, actionSelector);
         }
 
         /// <summary>
@@ -356,7 +438,34 @@ namespace Autofac.Integration.WebApi
             AsWebApiAuthorizationFilterOverrideFor<TController>(this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration)
                 where TController : IHttpController
         {
-            return AsFilterFor<IAutofacAuthorizationFilter, TController>(registration, AutofacWebApiFilterProvider.AuthorizationFilterOverrideMetadataKey);
+            return AsFilterFor<IAutofacAuthorizationFilter, TController>(registration, AutofacFilterCategory.AuthorizationFilterOverride);
+        }
+
+        /// <summary>
+        /// Sets the provided registration to act as an <see cref="IAutofacAuthorizationFilter"/> override for all controllers.
+        /// </summary>
+        /// <param name="registration">The registration.</param>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        public static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle>
+            AsWebApiAuthorizationFilterOverrideForAllControllers(this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration)
+        {
+            return AsFilterFor<IAutofacAuthorizationFilter>(registration, AutofacFilterCategory.AuthorizationFilterOverride, descriptor => true, FilterScope.Controller);
+        }
+
+        /// <summary>
+        /// Sets the provided registration to act as an <see cref="IAutofacAuthorizationFilter"/> override, based on a predicate that filters which actions it is applied to.
+        /// </summary>
+        /// <param name="registration">The registration.</param>
+        /// <param name="predicate">A predicate that should return true if this filter should be applied to the specified action.</param>
+        /// <param name="scope">The scope to apply the filter at (only Controller and Action supported).</param>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        public static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle>
+            AsWebApiAuthorizationFilterOverrideWhere(
+                this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration,
+                Func<HttpActionDescriptor, bool> predicate,
+                FilterScope scope = FilterScope.Action)
+        {
+            return AsFilterFor<IAutofacAuthorizationFilter>(registration, AutofacFilterCategory.AuthorizationFilterOverride, predicate, scope);
         }
 
         /// <summary>
@@ -370,7 +479,7 @@ namespace Autofac.Integration.WebApi
             AsWebApiExceptionFilterFor<TController>(this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration, Expression<Action<TController>> actionSelector)
                 where TController : IHttpController
         {
-            return AsFilterFor<IAutofacExceptionFilter, TController>(registration, AutofacWebApiFilterProvider.ExceptionFilterMetadataKey, actionSelector);
+            return AsFilterFor<IAutofacExceptionFilter, TController>(registration, AutofacFilterCategory.ExceptionFilter, actionSelector);
         }
 
         /// <summary>
@@ -383,7 +492,34 @@ namespace Autofac.Integration.WebApi
             AsWebApiExceptionFilterFor<TController>(this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration)
                 where TController : IHttpController
         {
-            return AsFilterFor<IAutofacExceptionFilter, TController>(registration, AutofacWebApiFilterProvider.ExceptionFilterMetadataKey);
+            return AsFilterFor<IAutofacExceptionFilter, TController>(registration, AutofacFilterCategory.ExceptionFilter);
+        }
+
+        /// <summary>
+        /// Sets the provided registration to act as an <see cref="IAutofacExceptionFilter"/> for all controllers.
+        /// </summary>
+        /// <param name="registration">The registration.</param>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        public static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle>
+            AsWebApiExceptionFilterForAllControllers(this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration)
+        {
+            return AsFilterFor<IAutofacExceptionFilter>(registration, AutofacFilterCategory.ExceptionFilter, descriptor => true, FilterScope.Controller);
+        }
+
+        /// <summary>
+        /// Sets the provided registration to act as an <see cref="IAutofacExceptionFilter"/>, based on a predicate that filters which actions it is applied to.
+        /// </summary>
+        /// <param name="registration">The registration.</param>
+        /// <param name="predicate">A predicate that should return true if this filter should be applied to the specified action.</param>
+        /// <param name="scope">The scope to apply the filter at (only Controller and Action supported).</param>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        public static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle>
+            AsWebApiExceptionFilterWhere(
+                this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration,
+                Func<HttpActionDescriptor, bool> predicate,
+                FilterScope scope = FilterScope.Action)
+        {
+            return AsFilterFor<IAutofacExceptionFilter>(registration, AutofacFilterCategory.ExceptionFilter, predicate, scope);
         }
 
         /// <summary>
@@ -397,7 +533,7 @@ namespace Autofac.Integration.WebApi
             AsWebApiExceptionFilterOverrideFor<TController>(this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration, Expression<Action<TController>> actionSelector)
                 where TController : IHttpController
         {
-            return AsFilterFor<IAutofacExceptionFilter, TController>(registration, AutofacWebApiFilterProvider.ExceptionFilterOverrideMetadataKey, actionSelector);
+            return AsFilterFor<IAutofacExceptionFilter, TController>(registration, AutofacFilterCategory.ExceptionFilterOverride, actionSelector);
         }
 
         /// <summary>
@@ -410,7 +546,34 @@ namespace Autofac.Integration.WebApi
             AsWebApiExceptionFilterOverrideFor<TController>(this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration)
                 where TController : IHttpController
         {
-            return AsFilterFor<IAutofacExceptionFilter, TController>(registration, AutofacWebApiFilterProvider.ExceptionFilterOverrideMetadataKey);
+            return AsFilterFor<IAutofacExceptionFilter, TController>(registration, AutofacFilterCategory.ExceptionFilterOverride);
+        }
+
+        /// <summary>
+        /// Sets the provided registration to act as an <see cref="IAutofacExceptionFilter"/> override for all controllers.
+        /// </summary>
+        /// <param name="registration">The registration.</param>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        public static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle>
+            AsWebApiExceptionFilterOverrideForAllControllers(this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration)
+        {
+            return AsFilterFor<IAutofacExceptionFilter>(registration, AutofacFilterCategory.ExceptionFilterOverride, descriptor => true, FilterScope.Controller);
+        }
+
+        /// <summary>
+        /// Sets the provided registration to act as an <see cref="IAutofacExceptionFilter"/> override, based on a predicate that filters which actions it is applied to.
+        /// </summary>
+        /// <param name="registration">The registration.</param>
+        /// <param name="predicate">A predicate that should return true if this filter should be applied to the specified action.</param>
+        /// <param name="scope">The scope to apply the filter at (only Controller and Action supported).</param>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        public static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle>
+            AsWebApiExceptionFilterOverrideWhere(
+                this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration,
+                Func<HttpActionDescriptor, bool> predicate,
+                FilterScope scope = FilterScope.Action)
+        {
+            return AsFilterFor<IAutofacExceptionFilter>(registration, AutofacFilterCategory.ExceptionFilterOverride, predicate, scope);
         }
 
         /// <summary>
@@ -424,7 +587,7 @@ namespace Autofac.Integration.WebApi
             AsWebApiAuthenticationFilterFor<TController>(this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration, Expression<Action<TController>> actionSelector)
                 where TController : IHttpController
         {
-            return AsFilterFor<IAutofacAuthenticationFilter, TController>(registration, AutofacWebApiFilterProvider.AuthenticationFilterMetadataKey, actionSelector);
+            return AsFilterFor<IAutofacAuthenticationFilter, TController>(registration, AutofacFilterCategory.AuthenticationFilter, actionSelector);
         }
 
         /// <summary>
@@ -437,7 +600,34 @@ namespace Autofac.Integration.WebApi
             AsWebApiAuthenticationFilterFor<TController>(this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration)
                 where TController : IHttpController
         {
-            return AsFilterFor<IAutofacAuthenticationFilter, TController>(registration, AutofacWebApiFilterProvider.AuthenticationFilterMetadataKey);
+            return AsFilterFor<IAutofacAuthenticationFilter, TController>(registration, AutofacFilterCategory.AuthenticationFilter);
+        }
+
+        /// <summary>
+        /// Sets the provided registration to act as an <see cref="IAuthenticationFilter"/> for all controllers.
+        /// </summary>
+        /// <param name="registration">The registration.</param>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        public static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle>
+            AsWebApiAuthenticationFilterForAllControllers(this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration)
+        {
+            return AsFilterFor<IAutofacAuthenticationFilter>(registration, AutofacFilterCategory.AuthenticationFilter, descriptor => true, FilterScope.Controller);
+        }
+
+        /// <summary>
+        /// Sets the provided registration to act as an <see cref="IAuthenticationFilter"/>, based on a predicate that filters which actions it is applied to.
+        /// </summary>
+        /// <param name="registration">The registration.</param>
+        /// <param name="predicate">A predicate that should return true if this filter should be applied to the specified action.</param>
+        /// <param name="scope">The scope to apply the filter at (only Controller and Action supported).</param>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        public static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle>
+            AsWebApiAuthenticationFilterWhere(
+                this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration,
+                Func<HttpActionDescriptor, bool> predicate,
+                FilterScope scope = FilterScope.Action)
+        {
+            return AsFilterFor<IAutofacAuthenticationFilter>(registration, AutofacFilterCategory.AuthenticationFilter, predicate, scope);
         }
 
         /// <summary>
@@ -451,7 +641,7 @@ namespace Autofac.Integration.WebApi
             AsWebApiAuthenticationFilterOverrideFor<TController>(this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration, Expression<Action<TController>> actionSelector)
                 where TController : IHttpController
         {
-            return AsFilterFor<IAutofacAuthenticationFilter, TController>(registration, AutofacWebApiFilterProvider.AuthenticationFilterOverrideMetadataKey, actionSelector);
+            return AsFilterFor<IAutofacAuthenticationFilter, TController>(registration, AutofacFilterCategory.AuthenticationFilterOverride, actionSelector);
         }
 
         /// <summary>
@@ -464,7 +654,34 @@ namespace Autofac.Integration.WebApi
             AsWebApiAuthenticationFilterOverrideFor<TController>(this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration)
                 where TController : IHttpController
         {
-            return AsFilterFor<IAutofacAuthenticationFilter, TController>(registration, AutofacWebApiFilterProvider.AuthenticationFilterOverrideMetadataKey);
+            return AsFilterFor<IAutofacAuthenticationFilter, TController>(registration, AutofacFilterCategory.AuthenticationFilterOverride);
+        }
+
+        /// <summary>
+        /// Sets the provided registration to act as an <see cref="IAuthenticationFilter"/> override for all controllers.
+        /// </summary>
+        /// <param name="registration">The registration.</param>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        public static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle>
+            AsWebApiAuthenticationFilterOverrideForAllControllers(this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration)
+        {
+            return AsFilterFor<IAuthenticationFilter>(registration, AutofacFilterCategory.AuthenticationFilterOverride, descriptor => true, FilterScope.Controller);
+        }
+
+        /// <summary>
+        /// Sets the provided registration to act as an <see cref="IAuthenticationFilter"/> override, based on a predicate that filters which actions it is applied to.
+        /// </summary>
+        /// <param name="registration">The registration.</param>
+        /// <param name="predicate">A predicate that should return true if this filter should be applied to the specified action.</param>
+        /// <param name="scope">The scope to apply the filter at (only Controller and Action supported).</param>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        public static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle>
+            AsWebApiAuthenticationFilterOverrideWhere(
+                this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration,
+                Func<HttpActionDescriptor, bool> predicate,
+                FilterScope scope = FilterScope.Action)
+        {
+            return AsFilterFor<IAuthenticationFilter>(registration, AutofacFilterCategory.AuthenticationFilterOverride, predicate, scope);
         }
 
         /// <summary>
@@ -475,7 +692,7 @@ namespace Autofac.Integration.WebApi
         public static void OverrideWebApiActionFilterFor<TController>(this ContainerBuilder builder, Expression<Action<TController>> actionSelector)
                 where TController : IHttpController
         {
-            AsOverrideFor<IActionFilter, TController>(builder, AutofacWebApiFilterProvider.ActionFilterOverrideMetadataKey, actionSelector);
+            AsOverrideFor<IActionFilter, TController>(builder, AutofacFilterCategory.ActionFilterOverride, actionSelector);
         }
 
         /// <summary>
@@ -485,7 +702,7 @@ namespace Autofac.Integration.WebApi
         public static void OverrideWebApiActionFilterFor<TController>(this ContainerBuilder builder)
                 where TController : IHttpController
         {
-            AsOverrideFor<IActionFilter, TController>(builder, AutofacWebApiFilterProvider.ActionFilterOverrideMetadataKey);
+            AsOverrideFor<IActionFilter, TController>(builder, AutofacFilterCategory.ActionFilterOverride);
         }
 
         /// <summary>
@@ -496,7 +713,7 @@ namespace Autofac.Integration.WebApi
         public static void OverrideWebApiAuthorizationFilterFor<TController>(this ContainerBuilder builder, Expression<Action<TController>> actionSelector)
                 where TController : IHttpController
         {
-            AsOverrideFor<IAuthorizationFilter, TController>(builder, AutofacWebApiFilterProvider.AuthorizationFilterOverrideMetadataKey, actionSelector);
+            AsOverrideFor<IAuthorizationFilter, TController>(builder, AutofacFilterCategory.AuthorizationFilterOverride, actionSelector);
         }
 
         /// <summary>
@@ -506,7 +723,7 @@ namespace Autofac.Integration.WebApi
         public static void OverrideWebApiAuthorizationFilterFor<TController>(this ContainerBuilder builder)
                 where TController : IHttpController
         {
-            AsOverrideFor<IAuthorizationFilter, TController>(builder, AutofacWebApiFilterProvider.AuthorizationFilterOverrideMetadataKey);
+            AsOverrideFor<IAuthorizationFilter, TController>(builder, AutofacFilterCategory.AuthorizationFilterOverride);
         }
 
         /// <summary>
@@ -517,7 +734,7 @@ namespace Autofac.Integration.WebApi
         public static void OverrideWebApiExceptionFilterFor<TController>(this ContainerBuilder builder, Expression<Action<TController>> actionSelector)
                 where TController : IHttpController
         {
-            AsOverrideFor<IExceptionFilter, TController>(builder, AutofacWebApiFilterProvider.ExceptionFilterOverrideMetadataKey, actionSelector);
+            AsOverrideFor<IExceptionFilter, TController>(builder, AutofacFilterCategory.ExceptionFilterOverride, actionSelector);
         }
 
         /// <summary>
@@ -527,7 +744,7 @@ namespace Autofac.Integration.WebApi
         public static void OverrideWebApiExceptionFilterFor<TController>(this ContainerBuilder builder)
                 where TController : IHttpController
         {
-            AsOverrideFor<IExceptionFilter, TController>(builder, AutofacWebApiFilterProvider.ExceptionFilterOverrideMetadataKey);
+            AsOverrideFor<IExceptionFilter, TController>(builder, AutofacFilterCategory.ExceptionFilterOverride);
         }
 
         /// <summary>
@@ -538,7 +755,7 @@ namespace Autofac.Integration.WebApi
         public static void OverrideWebApiAuthenticationFilterFor<TController>(this ContainerBuilder builder, Expression<Action<TController>> actionSelector)
                 where TController : IHttpController
         {
-            AsOverrideFor<IAuthenticationFilter, TController>(builder, AutofacWebApiFilterProvider.AuthenticationFilterOverrideMetadataKey, actionSelector);
+            AsOverrideFor<IAuthenticationFilter, TController>(builder, AutofacFilterCategory.AuthenticationFilterOverride, actionSelector);
         }
 
         /// <summary>
@@ -548,11 +765,50 @@ namespace Autofac.Integration.WebApi
         public static void OverrideWebApiAuthenticationFilterFor<TController>(this ContainerBuilder builder)
                 where TController : IHttpController
         {
-            AsOverrideFor<IAuthenticationFilter, TController>(builder, AutofacWebApiFilterProvider.AuthenticationFilterOverrideMetadataKey);
+            AsOverrideFor<IAuthenticationFilter, TController>(builder, AutofacFilterCategory.AuthenticationFilterOverride);
         }
 
         private static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle>
-            AsFilterFor<TFilter, TController>(IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration, string metadataKey)
+            AsFilterFor<TFilter>(
+                IRegistrationBuilder<object, IConcreteActivatorData,
+                SingleRegistrationStyle> registration,
+                AutofacFilterCategory filterCategory,
+                Func<HttpActionDescriptor, bool> predicate,
+                FilterScope scope)
+        {
+            if (registration == null) throw new ArgumentNullException(nameof(registration));
+            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+            if (scope != FilterScope.Action && scope != FilterScope.Controller) throw new InvalidEnumArgumentException(nameof(scope), (int)scope, typeof(FilterScope));
+
+            var limitType = registration.ActivatorData.Activator.LimitType;
+
+            if (!limitType.IsAssignableTo<TFilter>())
+            {
+                var message = string.Format(
+                    CultureInfo.CurrentCulture,
+                    RegistrationExtensionsResources.MustBeAssignableToFilterType,
+                    limitType.FullName,
+                    typeof(TFilter).FullName);
+                throw new ArgumentException(message, nameof(registration));
+            }
+
+            // Get the filter metadata set.
+            registration = registration.GetOrCreateMetadata(out FilterMetadata filterMeta);
+
+            var registrationMetadata = new FilterPredicateMetadata
+            {
+                Scope = scope,
+                FilterCategory = filterCategory,
+                Predicate = predicate
+            };
+
+            filterMeta.PredicateSet.Add(registrationMetadata);
+
+            return registration.As<TFilter>();
+        }
+
+        private static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle>
+            AsFilterFor<TFilter, TController>(IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration, AutofacFilterCategory filterCategory)
                 where TController : IHttpController
         {
             if (registration == null) throw new ArgumentNullException(nameof(registration));
@@ -569,18 +825,26 @@ namespace Autofac.Integration.WebApi
                 throw new ArgumentException(message, nameof(registration));
             }
 
-            var metadata = new FilterMetadata
+            // Get the filter metadata set.
+            registration = registration.GetOrCreateMetadata(out FilterMetadata filterMeta);
+
+            var registrationMetadata = new FilterPredicateMetadata
             {
-                ControllerType = typeof(TController),
-                FilterScope = FilterScope.Controller,
-                MethodInfo = null
+                Scope = FilterScope.Controller,
+                FilterCategory = filterCategory,
+                Predicate = descriptor => descriptor.ControllerDescriptor.ControllerType == typeof(TController)
             };
 
-            return registration.As<TFilter>().WithMetadata(metadataKey, metadata);
+            filterMeta.PredicateSet.Add(registrationMetadata);
+
+            return registration.As<TFilter>();
         }
 
         private static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle>
-            AsFilterFor<TFilter, TController>(IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration, string metadataKey, Expression<Action<TController>> actionSelector)
+            AsFilterFor<TFilter, TController>(
+                IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration,
+                AutofacFilterCategory filterCategory,
+                Expression<Action<TController>> actionSelector)
                 where TController : IHttpController
         {
             if (registration == null) throw new ArgumentNullException(nameof(registration));
@@ -598,44 +862,55 @@ namespace Autofac.Integration.WebApi
                 throw new ArgumentException(message, nameof(registration));
             }
 
-            var metadata = new FilterMetadata
+            // Get the filter metadata set.
+            registration = registration.GetOrCreateMetadata(out FilterMetadata filterMeta);
+
+            var method = GetMethodInfo(actionSelector);
+
+            var registrationMetadata = new FilterPredicateMetadata
             {
-                ControllerType = typeof(TController),
-                FilterScope = FilterScope.Action,
-                MethodInfo = GetMethodInfo(actionSelector)
+                Scope = FilterScope.Action,
+                FilterCategory = filterCategory,
+                Predicate = descriptor => typeof(TController).IsAssignableFrom(descriptor.ControllerDescriptor.ControllerType) &&
+                                          ActionMethodMatches(descriptor, method)
             };
 
-            return registration.As<TFilter>().WithMetadata(metadataKey, metadata);
+            filterMeta.PredicateSet.Add(registrationMetadata);
+
+            return registration.As<TFilter>();
         }
 
-        private static void AsOverrideFor<TFilter, TController>(ContainerBuilder builder, string metadataKey)
+        private static void AsOverrideFor<TFilter, TController>(ContainerBuilder builder, AutofacFilterCategory filterCategory)
         {
-            var metadata = new FilterMetadata
-            {
-                ControllerType = typeof(TController),
-                FilterScope = FilterScope.Controller,
-                MethodInfo = null
-            };
-
             builder.RegisterInstance(new AutofacOverrideFilter(typeof(TFilter)))
-                .As<IOverrideFilter>()
-                .WithMetadata(metadataKey, metadata);
+                  .As<IOverrideFilter>()
+                  .GetOrCreateOverrideMetadata(out var filterMetadata);
+
+            filterMetadata.PredicateSet.Add(new FilterPredicateMetadata
+            {
+                Scope = FilterScope.Controller,
+                FilterCategory = filterCategory,
+                Predicate = descriptor => typeof(TController).IsAssignableFrom(descriptor.ControllerDescriptor.ControllerType)
+            });
         }
 
-        private static void AsOverrideFor<TFilter, TController>(ContainerBuilder builder, string metadataKey, Expression<Action<TController>> actionSelector)
+        private static void AsOverrideFor<TFilter, TController>(ContainerBuilder builder, AutofacFilterCategory filterCategory, Expression<Action<TController>> actionSelector)
         {
             if (actionSelector == null) throw new ArgumentNullException(nameof(actionSelector));
 
-            var metadata = new FilterMetadata
-            {
-                ControllerType = typeof(TController),
-                FilterScope = FilterScope.Action,
-                MethodInfo = GetMethodInfo(actionSelector)
-            };
+            var methodInfo = GetMethodInfo(actionSelector);
 
             builder.RegisterInstance(new AutofacOverrideFilter(typeof(TFilter)))
                 .As<IOverrideFilter>()
-                .WithMetadata(metadataKey, metadata);
+                .GetOrCreateOverrideMetadata(out var filterMetadata);
+
+            filterMetadata.PredicateSet.Add(new FilterPredicateMetadata
+            {
+                Scope = FilterScope.Action,
+                FilterCategory = filterCategory,
+                Predicate = descriptor => typeof(TController).IsAssignableFrom(descriptor.ControllerDescriptor.ControllerType) &&
+                                          ActionMethodMatches(descriptor, methodInfo)
+            });
         }
 
         private static MethodInfo GetMethodInfo(LambdaExpression expression)
@@ -646,6 +921,64 @@ namespace Autofac.Integration.WebApi
                 throw new ArgumentException(RegistrationExtensionsResources.InvalidActionExpress);
 
             return outermostExpression.Method;
+        }
+
+        /// <summary>
+        /// Retrieve or create filter metadata. We want to maintain the fluent flow when we change
+        /// registration metadata so we'll do that here.
+        /// </summary>
+        private static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> GetOrCreateMetadata (
+            this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration,
+            out FilterMetadata filterMeta)
+        {
+            if (registration.RegistrationData.Metadata.TryGetValue(AutofacWebApiFilterProvider.FilterMetadataKey, out var filterDataObj))
+            {
+                filterMeta = (FilterMetadata)filterDataObj;
+            }
+            else
+            {
+                filterMeta = new FilterMetadata();
+                registration = registration.WithMetadata(AutofacWebApiFilterProvider.FilterMetadataKey, filterMeta);
+            }
+
+            return registration;
+        }
+
+        /// <summary>
+        /// Retrieve or create filter metadata for override filters. We want to maintain the fluent flow when we change
+        /// registration metadata so we'll do that here.
+        /// </summary>
+        private static IRegistrationBuilder<AutofacOverrideFilter, SimpleActivatorData, SingleRegistrationStyle> GetOrCreateOverrideMetadata(
+            this IRegistrationBuilder<AutofacOverrideFilter, SimpleActivatorData, SingleRegistrationStyle> registration,
+            out FilterMetadata filterMeta)
+        {
+            if (registration.RegistrationData.Metadata.TryGetValue(AutofacWebApiFilterProvider.FilterMetadataKey, out var filterDataObj))
+            {
+                filterMeta = (FilterMetadata)filterDataObj;
+            }
+            else
+            {
+                filterMeta = new FilterMetadata();
+                registration = registration.WithMetadata(AutofacWebApiFilterProvider.FilterMetadataKey, filterMeta);
+            }
+
+            return registration;
+        }
+
+        private static bool ActionMethodMatches(HttpActionDescriptor action, MethodInfo knownMethod)
+        {
+            var reflectedDescriptor = action as ReflectedHttpActionDescriptor;
+
+            if (reflectedDescriptor == null)
+            {
+                return false;
+            }
+
+            // Including fix for Issue #10 in new registration style:
+            // Comparing MethodInfo.MethodHandle rather than just MethodInfo equality
+            // because MethodInfo equality fails on a derived controller if the base class method
+            // isn't marked virtual... but MethodHandle correctly compares regardless.
+            return reflectedDescriptor.MethodInfo.GetBaseDefinition().MethodHandle == knownMethod.GetBaseDefinition().MethodHandle;
         }
     }
 }

--- a/src/Autofac.Integration.WebApi/RegistrationExtensions.cs
+++ b/src/Autofac.Integration.WebApi/RegistrationExtensions.cs
@@ -289,16 +289,33 @@ namespace Autofac.Integration.WebApi
         /// </summary>
         /// <param name="registration">The registration.</param>
         /// <param name="predicate">A predicate that should return true if this filter should be applied to the specified action.</param>
-        /// <param name="scope">The scope to apply the filter at (only Controller and Action supported).</param>
+        /// <param name="filterScope">The scope to apply the filter at (only Controller and Action supported).</param>
         /// <returns>A registration builder allowing further configuration of the component.</returns>
         public static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle>
             AsWebApiActionFilterWhere(
-                this IRegistrationBuilder<object, IConcreteActivatorData,
-                SingleRegistrationStyle> registration, Func<HttpActionDescriptor, bool> predicate,
-                FilterScope scope = FilterScope.Action)
+                this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration,
+                Func<HttpActionDescriptor, bool> predicate,
+                FilterScope filterScope = FilterScope.Action)
         {
-            return AsFilterFor<IAutofacActionFilter>(registration, AutofacFilterCategory.ActionFilter, predicate, scope);
+            return AsFilterFor<IAutofacActionFilter>(registration, AutofacFilterCategory.ActionFilter, predicate, filterScope);
         }
+
+        /// <summary>
+        /// Sets the provided registration to act as an <see cref="IAutofacActionFilter"/>, based on a predicate that filters which actions it is applied to.
+        /// </summary>
+        /// <param name="registration">The registration.</param>
+        /// <param name="predicate">A predicate that should return true if this filter should be applied to the specified action.</param>
+        /// <param name="filterScope">The scope to apply the filter at (only Controller and Action supported).</param>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        public static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle>
+            AsWebApiActionFilterWhere(
+                this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration,
+                Func<ILifetimeScope, HttpActionDescriptor, bool> predicate,
+                FilterScope filterScope = FilterScope.Action)
+        {
+            return AsFilterFor<IAutofacActionFilter>(registration, AutofacFilterCategory.ActionFilter, predicate, filterScope);
+        }
+
 
         /// <summary>
         /// Sets the provided registration to act as an <see cref="IAutofacActionFilter"/> override for the specified controller action.
@@ -345,15 +362,31 @@ namespace Autofac.Integration.WebApi
         /// </summary>
         /// <param name="registration">The registration.</param>
         /// <param name="predicate">A predicate that should return true if this filter should be applied to the specified action.</param>
-        /// <param name="scope">The scope to apply the filter at (only Controller and Action supported).</param>
+        /// <param name="filterScope">The scope to apply the filter at (only Controller and Action supported).</param>
         /// <returns>A registration builder allowing further configuration of the component.</returns>
         public static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle>
             AsWebApiActionFilterOverrideWhere(
-                this IRegistrationBuilder<object, IConcreteActivatorData,
-                    SingleRegistrationStyle> registration, Func<HttpActionDescriptor, bool> predicate,
-                FilterScope scope = FilterScope.Action)
+                this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration,
+                Func<HttpActionDescriptor, bool> predicate,
+                FilterScope filterScope = FilterScope.Action)
         {
-            return AsFilterFor<IAutofacActionFilter>(registration, AutofacFilterCategory.ActionFilterOverride, predicate, scope);
+            return AsFilterFor<IAutofacActionFilter>(registration, AutofacFilterCategory.ActionFilterOverride, predicate, filterScope);
+        }
+
+        /// <summary>
+        /// Sets the provided registration to act as an <see cref="IAutofacActionFilter"/> override, based on a predicate that filters which actions it is applied to.
+        /// </summary>
+        /// <param name="registration">The registration.</param>
+        /// <param name="predicate">A predicate that should return true if this filter should be applied to the specified action.</param>
+        /// <param name="filterScope">The scope to apply the filter at (only Controller and Action supported).</param>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        public static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle>
+            AsWebApiActionFilterOverrideWhere(
+                this IRegistrationBuilder<object, IConcreteActivatorData,SingleRegistrationStyle> registration,
+                Func<ILifetimeScope, HttpActionDescriptor, bool> predicate,
+                FilterScope filterScope = FilterScope.Action)
+        {
+            return AsFilterFor<IAutofacActionFilter>(registration, AutofacFilterCategory.ActionFilterOverride, predicate, filterScope);
         }
 
         /// <summary>
@@ -401,15 +434,31 @@ namespace Autofac.Integration.WebApi
         /// </summary>
         /// <param name="registration">The registration.</param>
         /// <param name="predicate">A predicate that should return true if this filter should be applied to the specified action.</param>
-        /// <param name="scope">The scope to apply the filter at (only Controller and Action supported).</param>
+        /// <param name="filterScope">The scope to apply the filter at (only Controller and Action supported).</param>
         /// <returns>A registration builder allowing further configuration of the component.</returns>
         public static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle>
             AsWebApiAuthorizationFilterWhere(
                 this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration,
                 Func<HttpActionDescriptor, bool> predicate,
-                FilterScope scope = FilterScope.Action)
+                FilterScope filterScope = FilterScope.Action)
         {
-            return AsFilterFor<IAutofacAuthorizationFilter>(registration, AutofacFilterCategory.AuthorizationFilter, predicate, scope);
+            return AsFilterFor<IAutofacAuthorizationFilter>(registration, AutofacFilterCategory.AuthorizationFilter, predicate, filterScope);
+        }
+
+        /// <summary>
+        /// Sets the provided registration to act as an <see cref="IAutofacAuthorizationFilter"/>, based on a predicate that filters which actions it is applied to.
+        /// </summary>
+        /// <param name="registration">The registration.</param>
+        /// <param name="predicate">A predicate that should return true if this filter should be applied to the specified action.</param>
+        /// <param name="filterScope">The scope to apply the filter at (only Controller and Action supported).</param>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        public static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle>
+            AsWebApiAuthorizationFilterWhere(
+                this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration,
+                Func<ILifetimeScope, HttpActionDescriptor, bool> predicate,
+                FilterScope filterScope = FilterScope.Action)
+        {
+            return AsFilterFor<IAutofacAuthorizationFilter>(registration, AutofacFilterCategory.AuthorizationFilter, predicate, filterScope);
         }
 
         /// <summary>
@@ -457,15 +506,31 @@ namespace Autofac.Integration.WebApi
         /// </summary>
         /// <param name="registration">The registration.</param>
         /// <param name="predicate">A predicate that should return true if this filter should be applied to the specified action.</param>
-        /// <param name="scope">The scope to apply the filter at (only Controller and Action supported).</param>
+        /// <param name="filterScope">The scope to apply the filter at (only Controller and Action supported).</param>
         /// <returns>A registration builder allowing further configuration of the component.</returns>
         public static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle>
             AsWebApiAuthorizationFilterOverrideWhere(
                 this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration,
                 Func<HttpActionDescriptor, bool> predicate,
-                FilterScope scope = FilterScope.Action)
+                FilterScope filterScope = FilterScope.Action)
         {
-            return AsFilterFor<IAutofacAuthorizationFilter>(registration, AutofacFilterCategory.AuthorizationFilterOverride, predicate, scope);
+            return AsFilterFor<IAutofacAuthorizationFilter>(registration, AutofacFilterCategory.AuthorizationFilterOverride, predicate, filterScope);
+        }
+
+        /// <summary>
+        /// Sets the provided registration to act as an <see cref="IAutofacAuthorizationFilter"/> override, based on a predicate that filters which actions it is applied to.
+        /// </summary>
+        /// <param name="registration">The registration.</param>
+        /// <param name="predicate">A predicate that should return true if this filter should be applied to the specified action.</param>
+        /// <param name="filterScope">The scope to apply the filter at (only Controller and Action supported).</param>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        public static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle>
+            AsWebApiAuthorizationFilterOverrideWhere(
+                this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration,
+                Func<ILifetimeScope, HttpActionDescriptor, bool> predicate,
+                FilterScope filterScope = FilterScope.Action)
+        {
+            return AsFilterFor<IAutofacAuthorizationFilter>(registration, AutofacFilterCategory.AuthorizationFilterOverride, predicate, filterScope);
         }
 
         /// <summary>
@@ -511,15 +576,31 @@ namespace Autofac.Integration.WebApi
         /// </summary>
         /// <param name="registration">The registration.</param>
         /// <param name="predicate">A predicate that should return true if this filter should be applied to the specified action.</param>
-        /// <param name="scope">The scope to apply the filter at (only Controller and Action supported).</param>
+        /// <param name="filterScope">The scope to apply the filter at (only Controller and Action supported).</param>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        public static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle>
+            AsWebApiExceptionFilterWhere(
+                this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration,
+                Func<ILifetimeScope, HttpActionDescriptor, bool> predicate,
+                FilterScope filterScope = FilterScope.Action)
+        {
+            return AsFilterFor<IAutofacExceptionFilter>(registration, AutofacFilterCategory.ExceptionFilter, predicate, filterScope);
+        }
+
+        /// <summary>
+        /// Sets the provided registration to act as an <see cref="IAutofacExceptionFilter"/>, based on a predicate that filters which actions it is applied to.
+        /// </summary>
+        /// <param name="registration">The registration.</param>
+        /// <param name="predicate">A predicate that should return true if this filter should be applied to the specified action.</param>
+        /// <param name="filterScope">The scope to apply the filter at (only Controller and Action supported).</param>
         /// <returns>A registration builder allowing further configuration of the component.</returns>
         public static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle>
             AsWebApiExceptionFilterWhere(
                 this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration,
                 Func<HttpActionDescriptor, bool> predicate,
-                FilterScope scope = FilterScope.Action)
+                FilterScope filterScope = FilterScope.Action)
         {
-            return AsFilterFor<IAutofacExceptionFilter>(registration, AutofacFilterCategory.ExceptionFilter, predicate, scope);
+            return AsFilterFor<IAutofacExceptionFilter>(registration, AutofacFilterCategory.ExceptionFilter, predicate, filterScope);
         }
 
         /// <summary>
@@ -565,15 +646,31 @@ namespace Autofac.Integration.WebApi
         /// </summary>
         /// <param name="registration">The registration.</param>
         /// <param name="predicate">A predicate that should return true if this filter should be applied to the specified action.</param>
-        /// <param name="scope">The scope to apply the filter at (only Controller and Action supported).</param>
+        /// <param name="filterScope">The scope to apply the filter at (only Controller and Action supported).</param>
         /// <returns>A registration builder allowing further configuration of the component.</returns>
         public static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle>
             AsWebApiExceptionFilterOverrideWhere(
                 this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration,
                 Func<HttpActionDescriptor, bool> predicate,
-                FilterScope scope = FilterScope.Action)
+                FilterScope filterScope = FilterScope.Action)
         {
-            return AsFilterFor<IAutofacExceptionFilter>(registration, AutofacFilterCategory.ExceptionFilterOverride, predicate, scope);
+            return AsFilterFor<IAutofacExceptionFilter>(registration, AutofacFilterCategory.ExceptionFilterOverride, predicate, filterScope);
+        }
+
+        /// <summary>
+        /// Sets the provided registration to act as an <see cref="IAutofacExceptionFilter"/> override, based on a predicate that filters which actions it is applied to.
+        /// </summary>
+        /// <param name="registration">The registration.</param>
+        /// <param name="predicate">A predicate that should return true if this filter should be applied to the specified action.</param>
+        /// <param name="filterScope">The scope to apply the filter at (only Controller and Action supported).</param>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        public static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle>
+            AsWebApiExceptionFilterOverrideWhere(
+                this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration,
+                Func<ILifetimeScope, HttpActionDescriptor, bool> predicate,
+                FilterScope filterScope = FilterScope.Action)
+        {
+            return AsFilterFor<IAutofacExceptionFilter>(registration, AutofacFilterCategory.ExceptionFilterOverride, predicate, filterScope);
         }
 
         /// <summary>
@@ -619,15 +716,31 @@ namespace Autofac.Integration.WebApi
         /// </summary>
         /// <param name="registration">The registration.</param>
         /// <param name="predicate">A predicate that should return true if this filter should be applied to the specified action.</param>
-        /// <param name="scope">The scope to apply the filter at (only Controller and Action supported).</param>
+        /// <param name="filterScope">The scope to apply the filter at (only Controller and Action supported).</param>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        public static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle>
+            AsWebApiAuthenticationFilterWhere(
+                this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration,
+                Func<ILifetimeScope, HttpActionDescriptor, bool> predicate,
+                FilterScope filterScope = FilterScope.Action)
+        {
+            return AsFilterFor<IAutofacAuthenticationFilter>(registration, AutofacFilterCategory.AuthenticationFilter, predicate, filterScope);
+        }
+
+        /// <summary>
+        /// Sets the provided registration to act as an <see cref="IAuthenticationFilter"/>, based on a predicate that filters which actions it is applied to.
+        /// </summary>
+        /// <param name="registration">The registration.</param>
+        /// <param name="predicate">A predicate that should return true if this filter should be applied to the specified action.</param>
+        /// <param name="filterScope">The scope to apply the filter at (only Controller and Action supported).</param>
         /// <returns>A registration builder allowing further configuration of the component.</returns>
         public static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle>
             AsWebApiAuthenticationFilterWhere(
                 this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration,
                 Func<HttpActionDescriptor, bool> predicate,
-                FilterScope scope = FilterScope.Action)
+                FilterScope filterScope = FilterScope.Action)
         {
-            return AsFilterFor<IAutofacAuthenticationFilter>(registration, AutofacFilterCategory.AuthenticationFilter, predicate, scope);
+            return AsFilterFor<IAutofacAuthenticationFilter>(registration, AutofacFilterCategory.AuthenticationFilter, predicate, filterScope);
         }
 
         /// <summary>
@@ -673,16 +786,33 @@ namespace Autofac.Integration.WebApi
         /// </summary>
         /// <param name="registration">The registration.</param>
         /// <param name="predicate">A predicate that should return true if this filter should be applied to the specified action.</param>
-        /// <param name="scope">The scope to apply the filter at (only Controller and Action supported).</param>
+        /// <param name="filterScope">The scope to apply the filter at (only Controller and Action supported).</param>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        public static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle>
+            AsWebApiAuthenticationFilterOverrideWhere(
+                this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration,
+                Func<ILifetimeScope, HttpActionDescriptor, bool> predicate,
+                FilterScope filterScope = FilterScope.Action)
+        {
+            return AsFilterFor<IAuthenticationFilter>(registration, AutofacFilterCategory.AuthenticationFilterOverride, predicate, filterScope);
+        }
+
+        /// <summary>
+        /// Sets the provided registration to act as an <see cref="IAuthenticationFilter"/> override, based on a predicate that filters which actions it is applied to.
+        /// </summary>
+        /// <param name="registration">The registration.</param>
+        /// <param name="predicate">A predicate that should return true if this filter should be applied to the specified action.</param>
+        /// <param name="filterScope">The scope to apply the filter at (only Controller and Action supported).</param>
         /// <returns>A registration builder allowing further configuration of the component.</returns>
         public static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle>
             AsWebApiAuthenticationFilterOverrideWhere(
                 this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration,
                 Func<HttpActionDescriptor, bool> predicate,
-                FilterScope scope = FilterScope.Action)
+                FilterScope filterScope = FilterScope.Action)
         {
-            return AsFilterFor<IAuthenticationFilter>(registration, AutofacFilterCategory.AuthenticationFilterOverride, predicate, scope);
+            return AsFilterFor<IAuthenticationFilter>(registration, AutofacFilterCategory.AuthenticationFilterOverride, predicate, filterScope);
         }
+
 
         /// <summary>
         /// Sets the provided registration to act as an <see cref="IOverrideFilter"/> for the specified controller action.
@@ -771,14 +901,26 @@ namespace Autofac.Integration.WebApi
         private static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle>
             AsFilterFor<TFilter>(
                 IRegistrationBuilder<object, IConcreteActivatorData,
-                SingleRegistrationStyle> registration,
+                    SingleRegistrationStyle> registration,
                 AutofacFilterCategory filterCategory,
                 Func<HttpActionDescriptor, bool> predicate,
-                FilterScope scope)
+                FilterScope filterScope)
+        {
+            return AsFilterFor<TFilter>(registration, filterCategory, (lifetime, action) => predicate(action), filterScope);
+        }
+
+        private static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle>
+            AsFilterFor<TFilter>(
+                IRegistrationBuilder<object, IConcreteActivatorData,
+                SingleRegistrationStyle> registration,
+                AutofacFilterCategory filterCategory,
+                Func<ILifetimeScope, HttpActionDescriptor, bool> predicate,
+                FilterScope filterScope)
         {
             if (registration == null) throw new ArgumentNullException(nameof(registration));
             if (predicate == null) throw new ArgumentNullException(nameof(predicate));
-            if (scope != FilterScope.Action && scope != FilterScope.Controller) throw new InvalidEnumArgumentException(nameof(scope), (int)scope, typeof(FilterScope));
+            if (filterScope != FilterScope.Action && filterScope != FilterScope.Controller)
+                throw new InvalidEnumArgumentException(nameof(filterScope), (int)filterScope, typeof(FilterScope));
 
             var limitType = registration.ActivatorData.Activator.LimitType;
 
@@ -797,7 +939,7 @@ namespace Autofac.Integration.WebApi
 
             var registrationMetadata = new FilterPredicateMetadata
             {
-                Scope = scope,
+                Scope = filterScope,
                 FilterCategory = filterCategory,
                 Predicate = predicate
             };
@@ -832,7 +974,7 @@ namespace Autofac.Integration.WebApi
             {
                 Scope = FilterScope.Controller,
                 FilterCategory = filterCategory,
-                Predicate = descriptor => descriptor.ControllerDescriptor.ControllerType == typeof(TController)
+                Predicate = (scope, descriptor) => descriptor.ControllerDescriptor.ControllerType == typeof(TController)
             };
 
             filterMeta.PredicateSet.Add(registrationMetadata);
@@ -871,8 +1013,8 @@ namespace Autofac.Integration.WebApi
             {
                 Scope = FilterScope.Action,
                 FilterCategory = filterCategory,
-                Predicate = descriptor => typeof(TController).IsAssignableFrom(descriptor.ControllerDescriptor.ControllerType) &&
-                                          ActionMethodMatches(descriptor, method)
+                Predicate = (scope, descriptor) => typeof(TController).IsAssignableFrom(descriptor.ControllerDescriptor.ControllerType) &&
+                                                   ActionMethodMatches(descriptor, method)
             };
 
             filterMeta.PredicateSet.Add(registrationMetadata);
@@ -890,7 +1032,7 @@ namespace Autofac.Integration.WebApi
             {
                 Scope = FilterScope.Controller,
                 FilterCategory = filterCategory,
-                Predicate = descriptor => typeof(TController).IsAssignableFrom(descriptor.ControllerDescriptor.ControllerType)
+                Predicate = (scope, descriptor) => typeof(TController).IsAssignableFrom(descriptor.ControllerDescriptor.ControllerType)
             });
         }
 
@@ -908,8 +1050,8 @@ namespace Autofac.Integration.WebApi
             {
                 Scope = FilterScope.Action,
                 FilterCategory = filterCategory,
-                Predicate = descriptor => typeof(TController).IsAssignableFrom(descriptor.ControllerDescriptor.ControllerType) &&
-                                          ActionMethodMatches(descriptor, methodInfo)
+                Predicate = (scope, descriptor) => typeof(TController).IsAssignableFrom(descriptor.ControllerDescriptor.ControllerType) &&
+                                                   ActionMethodMatches(descriptor, methodInfo)
             });
         }
 

--- a/test/Autofac.Integration.WebApi.Test/ActionFilterFixture.cs
+++ b/test/Autofac.Integration.WebApi.Test/ActionFilterFixture.cs
@@ -40,7 +40,7 @@ namespace Autofac.Integration.WebApi.Test
                          .AsWebApiActionFilterFor<TestControllerB>();
         }
 
-        protected override Action<IRegistrationBuilder<TestActionFilter, SimpleActivatorData, SingleRegistrationStyle>> ConfigureFirstPredicateRegistration(Func<HttpActionDescriptor, bool> predicate)
+        protected override Action<IRegistrationBuilder<TestActionFilter, SimpleActivatorData, SingleRegistrationStyle>> ConfigureFirstPredicateRegistration(Func<ILifetimeScope, HttpActionDescriptor, bool> predicate)
         {
             return r => r.AsWebApiActionFilterWhere(predicate);
         }

--- a/test/Autofac.Integration.WebApi.Test/ActionFilterFixture.cs
+++ b/test/Autofac.Integration.WebApi.Test/ActionFilterFixture.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Web.Http.Controllers;
 using System.Web.Http.Filters;
 using Autofac.Builder;
 using Autofac.Integration.WebApi;
@@ -28,6 +29,22 @@ namespace Autofac.Integration.WebApi.Test
             return r => r.AsWebApiActionFilterFor<TestController>(c => c.Get());
         }
 
+        protected override Action<IRegistrationBuilder<TestActionFilter, SimpleActivatorData, SingleRegistrationStyle>> ConfigureFirstAllControllersRegistration()
+        {
+            return r => r.AsWebApiActionFilterForAllControllers();
+        }
+
+        protected override Action<IRegistrationBuilder<TestActionFilter, SimpleActivatorData, SingleRegistrationStyle>> ConfigureFirstChainedControllersRegistration()
+        {
+            return r => r.AsWebApiActionFilterFor<TestControllerA>()
+                         .AsWebApiActionFilterFor<TestControllerB>();
+        }
+
+        protected override Action<IRegistrationBuilder<TestActionFilter, SimpleActivatorData, SingleRegistrationStyle>> ConfigureFirstPredicateRegistration(Func<HttpActionDescriptor, bool> predicate)
+        {
+            return r => r.AsWebApiActionFilterWhere(predicate);
+        }
+
         protected override Action<IRegistrationBuilder<TestActionFilter2, SimpleActivatorData, SingleRegistrationStyle>> ConfigureSecondControllerRegistration()
         {
             return r => r.AsWebApiActionFilterFor<TestController>();
@@ -36,6 +53,22 @@ namespace Autofac.Integration.WebApi.Test
         protected override Action<IRegistrationBuilder<TestActionFilter2, SimpleActivatorData, SingleRegistrationStyle>> ConfigureSecondActionRegistration()
         {
             return r => r.AsWebApiActionFilterFor<TestController>(c => c.Get());
+        }
+
+        protected override Action<IRegistrationBuilder<TestActionFilter2, SimpleActivatorData, SingleRegistrationStyle>> ConfigureSecondAllControllersRegistration()
+        {
+            return r => r.AsWebApiActionFilterForAllControllers();
+        }
+
+        protected override Action<IRegistrationBuilder<TestActionFilter2, SimpleActivatorData, SingleRegistrationStyle>> ConfigureSecondChainedControllersRegistration()
+        {
+            return r => r.AsWebApiActionFilterFor<TestControllerA>()
+                         .AsWebApiActionFilterFor<TestControllerB>();
+        }
+
+        protected override Action<IRegistrationBuilder<TestActionFilter2, SimpleActivatorData, SingleRegistrationStyle>> ConfigureSecondPredicateRegistration(Func<HttpActionDescriptor, bool> predicate)
+        {
+            return r => r.AsWebApiActionFilterWhere(predicate);
         }
 
         protected override Type GetWrapperType()

--- a/test/Autofac.Integration.WebApi.Test/ActionFilterOverrideWrapperFixture.cs
+++ b/test/Autofac.Integration.WebApi.Test/ActionFilterOverrideWrapperFixture.cs
@@ -1,4 +1,5 @@
-﻿using System.Web.Http.Filters;
+﻿using System.Collections.Generic;
+using System.Web.Http.Filters;
 using Autofac.Integration.WebApi;
 using Xunit;
 
@@ -7,16 +8,9 @@ namespace Autofac.Integration.WebApi.Test
     public class ActionFilterOverrideWrapperFixture
     {
         [Fact]
-        public void MetadataKeyReturnsOverrideValue()
-        {
-            var wrapper = new ActionFilterOverrideWrapper(new FilterMetadata());
-            Assert.Equal(AutofacWebApiFilterProvider.ActionFilterOverrideMetadataKey, wrapper.MetadataKey);
-        }
-
-        [Fact]
         public void FiltersToOverrideReturnsCorrectType()
         {
-            var wrapper = new ActionFilterOverrideWrapper(new FilterMetadata());
+            var wrapper = new ActionFilterOverrideWrapper(new HashSet<FilterMetadata>());
             Assert.Equal(typeof(IActionFilter), wrapper.FiltersToOverride);
         }
     }

--- a/test/Autofac.Integration.WebApi.Test/AuthenticationFilterFixture.cs
+++ b/test/Autofac.Integration.WebApi.Test/AuthenticationFilterFixture.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Web.Http.Controllers;
 using System.Web.Http.Filters;
 using Autofac.Builder;
 using Autofac.Integration.WebApi;
@@ -28,6 +29,22 @@ namespace Autofac.Integration.WebApi.Test
             return r => r.AsWebApiAuthenticationFilterFor<TestController>(c => c.Get());
         }
 
+        protected override Action<IRegistrationBuilder<TestAuthenticationFilter, SimpleActivatorData, SingleRegistrationStyle>> ConfigureFirstAllControllersRegistration()
+        {
+            return r => r.AsWebApiAuthenticationFilterForAllControllers();
+        }
+
+        protected override Action<IRegistrationBuilder<TestAuthenticationFilter, SimpleActivatorData, SingleRegistrationStyle>> ConfigureFirstChainedControllersRegistration()
+        {
+            return r => r.AsWebApiAuthenticationFilterFor<TestControllerA>()
+                         .AsWebApiAuthenticationFilterFor<TestControllerB>();
+        }
+
+        protected override Action<IRegistrationBuilder<TestAuthenticationFilter, SimpleActivatorData, SingleRegistrationStyle>> ConfigureFirstPredicateRegistration(Func<HttpActionDescriptor, bool> predicate)
+        {
+            return r => r.AsWebApiAuthenticationFilterWhere(predicate);
+        }
+
         protected override Action<IRegistrationBuilder<TestAuthenticationFilter2, SimpleActivatorData, SingleRegistrationStyle>> ConfigureSecondControllerRegistration()
         {
             return r => r.AsWebApiAuthenticationFilterFor<TestController>();
@@ -36,6 +53,22 @@ namespace Autofac.Integration.WebApi.Test
         protected override Action<IRegistrationBuilder<TestAuthenticationFilter2, SimpleActivatorData, SingleRegistrationStyle>> ConfigureSecondActionRegistration()
         {
             return r => r.AsWebApiAuthenticationFilterFor<TestController>(c => c.Get());
+        }
+
+        protected override Action<IRegistrationBuilder<TestAuthenticationFilter2, SimpleActivatorData, SingleRegistrationStyle>> ConfigureSecondAllControllersRegistration()
+        {
+            return r => r.AsWebApiAuthenticationFilterForAllControllers();
+        }
+
+        protected override Action<IRegistrationBuilder<TestAuthenticationFilter2, SimpleActivatorData, SingleRegistrationStyle>> ConfigureSecondChainedControllersRegistration()
+        {
+            return r => r.AsWebApiAuthenticationFilterFor<TestControllerA>()
+                         .AsWebApiAuthenticationFilterFor<TestControllerB>();
+        }
+
+        protected override Action<IRegistrationBuilder<TestAuthenticationFilter2, SimpleActivatorData, SingleRegistrationStyle>> ConfigureSecondPredicateRegistration(Func<HttpActionDescriptor, bool> predicate)
+        {
+            return r => r.AsWebApiAuthenticationFilterWhere(predicate);
         }
 
         protected override Type GetWrapperType()

--- a/test/Autofac.Integration.WebApi.Test/AuthenticationFilterFixture.cs
+++ b/test/Autofac.Integration.WebApi.Test/AuthenticationFilterFixture.cs
@@ -40,7 +40,7 @@ namespace Autofac.Integration.WebApi.Test
                          .AsWebApiAuthenticationFilterFor<TestControllerB>();
         }
 
-        protected override Action<IRegistrationBuilder<TestAuthenticationFilter, SimpleActivatorData, SingleRegistrationStyle>> ConfigureFirstPredicateRegistration(Func<HttpActionDescriptor, bool> predicate)
+        protected override Action<IRegistrationBuilder<TestAuthenticationFilter, SimpleActivatorData, SingleRegistrationStyle>> ConfigureFirstPredicateRegistration(Func<ILifetimeScope, HttpActionDescriptor, bool> predicate)
         {
             return r => r.AsWebApiAuthenticationFilterWhere(predicate);
         }

--- a/test/Autofac.Integration.WebApi.Test/AuthenticationFilterOverrideWrapperFixture.cs
+++ b/test/Autofac.Integration.WebApi.Test/AuthenticationFilterOverrideWrapperFixture.cs
@@ -1,4 +1,5 @@
-﻿using System.Web.Http.Filters;
+﻿using System.Collections.Generic;
+using System.Web.Http.Filters;
 using Xunit;
 
 namespace Autofac.Integration.WebApi.Test
@@ -6,16 +7,9 @@ namespace Autofac.Integration.WebApi.Test
     public class AuthenticationFilterOverrideWrapperFixture
     {
         [Fact]
-        public void MetadataKeyReturnsOverrideValue()
-        {
-            var wrapper = new AuthenticationFilterOverrideWrapper(new FilterMetadata());
-            Assert.Equal(AutofacWebApiFilterProvider.AuthenticationFilterOverrideMetadataKey, wrapper.MetadataKey);
-        }
-
-        [Fact]
         public void FiltersToOverrideReturnsCorrectType()
         {
-            var wrapper = new AuthenticationFilterOverrideWrapper(new FilterMetadata());
+            var wrapper = new AuthenticationFilterOverrideWrapper(new HashSet<FilterMetadata>());
             Assert.Equal(typeof(IAuthenticationFilter), wrapper.FiltersToOverride);
         }
     }

--- a/test/Autofac.Integration.WebApi.Test/AuthenticationFilterWrapperFixture.cs
+++ b/test/Autofac.Integration.WebApi.Test/AuthenticationFilterWrapperFixture.cs
@@ -1,10 +1,13 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Web.Http;
 using System.Web.Http.Controllers;
 using System.Web.Http.Filters;
 using System.Web.Http.Hosting;
+using System.Web.Http.Results;
 using Autofac.Integration.WebApi.Test.TestTypes;
 using Xunit;
 
@@ -20,15 +23,15 @@ namespace Autofac.Integration.WebApi.Test
         }
 
         [Fact]
-        public async void WrapperResolvesAuthenticationFilterFromDependencyScope()
+        public async void WrapperExecutesAuthenticationFilters()
         {
             var builder = new ContainerBuilder();
-            builder.Register<ILogger>(c => new Logger()).InstancePerDependency();
-            var activationCount = 0;
+            var output = new List<string>();
+            builder.Register<ILogger>(c => new DelegatingLogger(m => output.Add(m))).InstancePerDependency();
             builder.Register<IAutofacAuthenticationFilter>(c => new TestAuthenticationFilter(c.Resolve<ILogger>()))
                 .AsWebApiAuthenticationFilterFor<TestController>(c => c.Get())
                 .InstancePerRequest()
-                .OnActivated(e => activationCount++);
+                .GetMetadata(out var filterMetadata);
             var container = builder.Build();
 
             var resolver = new AutofacWebApiDependencyResolver(container);
@@ -41,15 +44,51 @@ namespace Autofac.Integration.WebApi.Test
             var actionDescriptor = new ReflectedHttpActionDescriptor(controllerDescriptor, methodInfo);
             var actionContext = new HttpActionContext(contollerContext, actionDescriptor);
             var context = new HttpAuthenticationContext(actionContext, Thread.CurrentPrincipal);
-            var metadata = new FilterMetadata
-            {
-                ControllerType = typeof(TestController),
-                FilterScope = FilterScope.Action,
-                MethodInfo = methodInfo
-            };
-            var wrapper = new AuthenticationFilterWrapper(metadata);
+
+            var challengeContext = new HttpAuthenticationChallengeContext(actionContext, new StatusCodeResult(HttpStatusCode.Forbidden, requestMessage));
+
+            var wrapper = new AuthenticationFilterWrapper(filterMetadata.ToSingleFilterHashSet());
 
             await wrapper.AuthenticateAsync(context, CancellationToken.None);
+
+            await wrapper.ChallengeAsync(challengeContext, CancellationToken.None);
+
+            Assert.Equal(nameof(wrapper.AuthenticateAsync), output[0]);
+            Assert.Equal(nameof(wrapper.ChallengeAsync), output[1]);
+        }
+
+        [Fact]
+        public async void WrapperResolvesAuthenticationFilterFromDependencyScope()
+        {
+            var builder = new ContainerBuilder();
+            builder.Register<ILogger>(c => new Logger()).InstancePerDependency();
+            var activationCount = 0;
+            builder.Register<IAutofacAuthenticationFilter>(c => new TestAuthenticationFilter(c.Resolve<ILogger>()))
+                .AsWebApiAuthenticationFilterFor<TestController>(c => c.Get())
+                .InstancePerRequest()
+                .OnActivated(e => activationCount++)
+                .GetMetadata(out var filterMetadata);
+            var container = builder.Build();
+
+            var resolver = new AutofacWebApiDependencyResolver(container);
+            var configuration = new HttpConfiguration { DependencyResolver = resolver };
+            var requestMessage = new HttpRequestMessage();
+            requestMessage.Properties.Add(HttpPropertyKeys.HttpConfigurationKey, configuration);
+            var contollerContext = new HttpControllerContext { Request = requestMessage };
+            var controllerDescriptor = new HttpControllerDescriptor { ControllerType = typeof(TestController) };
+            var methodInfo = typeof(TestController).GetMethod("Get");
+            var actionDescriptor = new ReflectedHttpActionDescriptor(controllerDescriptor, methodInfo);
+            var actionContext = new HttpActionContext(contollerContext, actionDescriptor);
+            var context = new HttpAuthenticationContext(actionContext, Thread.CurrentPrincipal);
+
+            var challengeContext = new HttpAuthenticationChallengeContext(actionContext, new StatusCodeResult(HttpStatusCode.Forbidden, requestMessage));
+
+            var wrapper = new AuthenticationFilterWrapper(filterMetadata.ToSingleFilterHashSet());
+
+            await wrapper.AuthenticateAsync(context, CancellationToken.None);
+
+            await wrapper.ChallengeAsync(challengeContext, CancellationToken.None);
+
             Assert.Equal(1, activationCount);
         }
     }

--- a/test/Autofac.Integration.WebApi.Test/AuthorizationFilterFixture.cs
+++ b/test/Autofac.Integration.WebApi.Test/AuthorizationFilterFixture.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Web.Http.Controllers;
 using System.Web.Http.Filters;
 using Autofac.Builder;
 using Autofac.Integration.WebApi;
@@ -28,6 +29,22 @@ namespace Autofac.Integration.WebApi.Test
             return r => r.AsWebApiAuthorizationFilterFor<TestController>(c => c.Get());
         }
 
+        protected override Action<IRegistrationBuilder<TestAuthorizationFilter, SimpleActivatorData, SingleRegistrationStyle>> ConfigureFirstAllControllersRegistration()
+        {
+            return r => r.AsWebApiAuthorizationFilterForAllControllers();
+        }
+
+        protected override Action<IRegistrationBuilder<TestAuthorizationFilter, SimpleActivatorData, SingleRegistrationStyle>> ConfigureFirstChainedControllersRegistration()
+        {
+            return r => r.AsWebApiAuthorizationFilterFor<TestControllerA>()
+                         .AsWebApiAuthorizationFilterFor<TestControllerB>();
+        }
+
+        protected override Action<IRegistrationBuilder<TestAuthorizationFilter, SimpleActivatorData, SingleRegistrationStyle>> ConfigureFirstPredicateRegistration(Func<HttpActionDescriptor, bool> predicate)
+        {
+            return r => r.AsWebApiAuthorizationFilterWhere(predicate);
+        }
+
         protected override Action<IRegistrationBuilder<TestAuthorizationFilter2, SimpleActivatorData, SingleRegistrationStyle>> ConfigureSecondControllerRegistration()
         {
             return r => r.AsWebApiAuthorizationFilterFor<TestController>();
@@ -36,6 +53,22 @@ namespace Autofac.Integration.WebApi.Test
         protected override Action<IRegistrationBuilder<TestAuthorizationFilter2, SimpleActivatorData, SingleRegistrationStyle>> ConfigureSecondActionRegistration()
         {
             return r => r.AsWebApiAuthorizationFilterFor<TestController>(c => c.Get());
+        }
+
+        protected override Action<IRegistrationBuilder<TestAuthorizationFilter2, SimpleActivatorData, SingleRegistrationStyle>> ConfigureSecondAllControllersRegistration()
+        {
+            return r => r.AsWebApiAuthorizationFilterForAllControllers();
+        }
+
+        protected override Action<IRegistrationBuilder<TestAuthorizationFilter2, SimpleActivatorData, SingleRegistrationStyle>> ConfigureSecondChainedControllersRegistration()
+        {
+            return r => r.AsWebApiAuthorizationFilterFor<TestControllerA>()
+                         .AsWebApiAuthorizationFilterFor<TestControllerB>();
+        }
+
+        protected override Action<IRegistrationBuilder<TestAuthorizationFilter2, SimpleActivatorData, SingleRegistrationStyle>> ConfigureSecondPredicateRegistration(Func<HttpActionDescriptor, bool> predicate)
+        {
+            return r => r.AsWebApiAuthorizationFilterWhere(predicate);
         }
 
         protected override Type GetWrapperType()

--- a/test/Autofac.Integration.WebApi.Test/AuthorizationFilterFixture.cs
+++ b/test/Autofac.Integration.WebApi.Test/AuthorizationFilterFixture.cs
@@ -40,7 +40,7 @@ namespace Autofac.Integration.WebApi.Test
                          .AsWebApiAuthorizationFilterFor<TestControllerB>();
         }
 
-        protected override Action<IRegistrationBuilder<TestAuthorizationFilter, SimpleActivatorData, SingleRegistrationStyle>> ConfigureFirstPredicateRegistration(Func<HttpActionDescriptor, bool> predicate)
+        protected override Action<IRegistrationBuilder<TestAuthorizationFilter, SimpleActivatorData, SingleRegistrationStyle>> ConfigureFirstPredicateRegistration(Func<ILifetimeScope, HttpActionDescriptor, bool> predicate)
         {
             return r => r.AsWebApiAuthorizationFilterWhere(predicate);
         }

--- a/test/Autofac.Integration.WebApi.Test/AuthorizationFilterOverrideWrapperFixture.cs
+++ b/test/Autofac.Integration.WebApi.Test/AuthorizationFilterOverrideWrapperFixture.cs
@@ -1,4 +1,5 @@
-﻿using System.Web.Http.Filters;
+﻿using System.Collections.Generic;
+using System.Web.Http.Filters;
 using Xunit;
 
 namespace Autofac.Integration.WebApi.Test
@@ -6,16 +7,9 @@ namespace Autofac.Integration.WebApi.Test
     public class AuthorizationFilterOverrideWrapperFixture
     {
         [Fact]
-        public void MetadataKeyReturnsOverrideValue()
-        {
-            var wrapper = new AuthorizationFilterOverrideWrapper(new FilterMetadata());
-            Assert.Equal(AutofacWebApiFilterProvider.AuthorizationFilterOverrideMetadataKey, wrapper.MetadataKey);
-        }
-
-        [Fact]
         public void FiltersToOverrideReturnsCorrectType()
         {
-            var wrapper = new AuthorizationFilterOverrideWrapper(new FilterMetadata());
+            var wrapper = new AuthorizationFilterOverrideWrapper(new HashSet<FilterMetadata>());
             Assert.Equal(typeof(IAuthorizationFilter), wrapper.FiltersToOverride);
         }
     }

--- a/test/Autofac.Integration.WebApi.Test/Autofac.Integration.WebApi.Test.csproj
+++ b/test/Autofac.Integration.WebApi.Test/Autofac.Integration.WebApi.Test.csproj
@@ -79,6 +79,7 @@
     <Compile Include="ExceptionFilterWrapperFixture.cs" />
     <Compile Include="AutofacControllerConfigurationAttributeFixture.cs" />
     <Compile Include="AutofacFilterBaseFixture.cs" />
+    <Compile Include="FilterMetadataExtensions.cs" />
     <Compile Include="FilterOrderingFixture.cs" />
     <Compile Include="HttpConfigurationExtensionsFixture.cs" />
     <Compile Include="HttpRequestMessageProviderFixture.cs" />

--- a/test/Autofac.Integration.WebApi.Test/AutofacFilterBaseFixture.cs
+++ b/test/Autofac.Integration.WebApi.Test/AutofacFilterBaseFixture.cs
@@ -162,7 +162,7 @@ namespace Autofac.Integration.WebApi.Test
         {
             AssertSingleFilter<TestControllerA>(
                 GetFirstRegistration(),
-                ConfigureFirstPredicateRegistration(descriptor => descriptor.ControllerDescriptor.ControllerType == typeof(TestControllerA)));
+                ConfigureFirstPredicateRegistration((scope, descriptor) => descriptor.ControllerDescriptor.ControllerType == typeof(TestControllerA)));
         }
 
         [Fact]
@@ -171,7 +171,7 @@ namespace Autofac.Integration.WebApi.Test
             AssertMultipleFilters(
                 GetFirstRegistration(),
                 GetSecondRegistration(),
-                ConfigureFirstPredicateRegistration(descriptor => descriptor.ControllerDescriptor.ControllerType == typeof(TestController)),
+                ConfigureFirstPredicateRegistration((scope, descriptor) => descriptor.ControllerDescriptor.ControllerType == typeof(TestController)),
                 ConfigureSecondPredicateRegistration(descriptor => descriptor.ControllerDescriptor.ControllerType == typeof(TestController)));
         }
 
@@ -180,7 +180,20 @@ namespace Autofac.Integration.WebApi.Test
         {
             AssertNoFilter<TestControllerB>(
                 GetFirstRegistration(),
-                ConfigureFirstPredicateRegistration(descriptor => descriptor.ControllerDescriptor.ControllerType == typeof(TestControllerA)));
+                ConfigureFirstPredicateRegistration((scope, descriptor) => descriptor.ControllerDescriptor.ControllerType == typeof(TestControllerA)));
+        }
+
+        [Fact]
+        public void CanUseLifetimeScopeInPredicate()
+        {
+            AssertNoFilter<TestControllerB>(
+                GetFirstRegistration(),
+                ConfigureFirstPredicateRegistration((scope, descriptor) =>
+                {
+                    Assert.NotNull(scope.Resolve<ILogger>());
+
+                    return descriptor.ControllerDescriptor.ControllerType == typeof(TestControllerA);
+                }));
         }
 
         protected abstract Func<IComponentContext, TFilter1> GetFirstRegistration();
@@ -195,7 +208,7 @@ namespace Autofac.Integration.WebApi.Test
 
         protected abstract Action<IRegistrationBuilder<TFilter1, SimpleActivatorData, SingleRegistrationStyle>> ConfigureFirstChainedControllersRegistration();
 
-        protected abstract Action<IRegistrationBuilder<TFilter1, SimpleActivatorData, SingleRegistrationStyle>> ConfigureFirstPredicateRegistration(Func<HttpActionDescriptor, bool> predicate);
+        protected abstract Action<IRegistrationBuilder<TFilter1, SimpleActivatorData, SingleRegistrationStyle>> ConfigureFirstPredicateRegistration(Func<ILifetimeScope, HttpActionDescriptor, bool> predicate);
 
         protected abstract Action<IRegistrationBuilder<TFilter2, SimpleActivatorData, SingleRegistrationStyle>> ConfigureSecondControllerRegistration();
 

--- a/test/Autofac.Integration.WebApi.Test/AutofacFilterBaseFixture.cs
+++ b/test/Autofac.Integration.WebApi.Test/AutofacFilterBaseFixture.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Web.Http;
 using System.Web.Http.Controllers;
+using System.Web.Http.Filters;
 using Autofac.Builder;
 using Autofac.Integration.WebApi.Test.TestTypes;
 using Xunit;
@@ -27,7 +28,7 @@ namespace Autofac.Integration.WebApi.Test
         }
 
         [Fact]
-        public void ResolvesActionScopedFilterForImmediateBaseContoller()
+        public void ResolvesActionScopedFilterForImmediateBaseController()
         {
             AssertSingleFilter<TestControllerA>(
                 GetFirstRegistration(),
@@ -35,7 +36,7 @@ namespace Autofac.Integration.WebApi.Test
         }
 
         [Fact]
-        public void ResolvesActionScopedFilterForMostBaseContoller()
+        public void ResolvesActionScopedFilterForMostBaseController()
         {
             AssertSingleFilter<TestControllerB>(
                 GetFirstRegistration(),
@@ -77,28 +78,28 @@ namespace Autofac.Integration.WebApi.Test
         }
 
         [Fact]
-        public void ResolvesActionScopedOverrideFilterForImmediateBaseContoller()
+        public void ResolvesActionScopedOverrideFilterForImmediateBaseController()
         {
             AssertOverrideFilter<TestControllerA>(
                 ConfigureActionFilterOverride());
         }
 
         [Fact]
-        public void ResolvesActionScopedOverrideFilterForMostBaseContoller()
+        public void ResolvesActionScopedOverrideFilterForMostBaseController()
         {
             AssertOverrideFilter<TestControllerB>(
                 ConfigureActionFilterOverride());
         }
 
         [Fact]
-        public void ResolvesControllerScopedOverrideFilterForImmediateBaseContoller()
+        public void ResolvesControllerScopedOverrideFilterForImmediateBaseController()
         {
             AssertOverrideFilter<TestControllerA>(
                 ConfigureControllerFilterOverride());
         }
 
         [Fact]
-        public void ResolvesControllerScopedOverrideFilterForMostBaseContoller()
+        public void ResolvesControllerScopedOverrideFilterForMostBaseController()
         {
             AssertOverrideFilter<TestControllerB>(
                 ConfigureControllerFilterOverride());
@@ -120,6 +121,68 @@ namespace Autofac.Integration.WebApi.Test
                 ConfigureControllerOverrideRegistration());
         }
 
+        [Fact]
+        public void ResolvesRegisteredActionFilterForAllControllers()
+        {
+            AssertMultiControllerRegistration<TestControllerA, TestControllerB>(
+                GetFirstRegistration(),
+                ConfigureFirstAllControllersRegistration());
+        }
+
+        [Fact]
+        public void ResolvesRegisteredActionFilterForMultipleAllControllersRegistration()
+        {
+            AssertMultiControllerRegistration<TestControllerA, TestControllerB>(
+                GetFirstRegistration(),
+                GetSecondRegistration(),
+                ConfigureFirstAllControllersRegistration(),
+                ConfigureSecondAllControllersRegistration());
+        }
+
+        [Fact]
+        public void ResolvesRegisteredActionFilterForChainedControllers()
+        {
+            AssertMultiControllerRegistration<TestControllerA, TestControllerB>(
+                GetFirstRegistration(),
+                ConfigureFirstChainedControllersRegistration());
+        }
+
+        [Fact]
+        public void ResolvesRegisteredActionFilterForMultipleChainedControllersRegistration()
+        {
+            AssertMultiControllerRegistration<TestControllerA, TestControllerB>(
+                GetFirstRegistration(),
+                GetSecondRegistration(),
+                ConfigureFirstChainedControllersRegistration(),
+                ConfigureSecondChainedControllersRegistration());
+        }
+
+        [Fact]
+        public void ResolvesRegisteredActionFilterForPredicateRegistration()
+        {
+            AssertSingleFilter<TestControllerA>(
+                GetFirstRegistration(),
+                ConfigureFirstPredicateRegistration(descriptor => descriptor.ControllerDescriptor.ControllerType == typeof(TestControllerA)));
+        }
+
+        [Fact]
+        public void ResolvesRegisteredActionFilterForMultiplePredicateRegistration()
+        {
+            AssertMultipleFilters(
+                GetFirstRegistration(),
+                GetSecondRegistration(),
+                ConfigureFirstPredicateRegistration(descriptor => descriptor.ControllerDescriptor.ControllerType == typeof(TestController)),
+                ConfigureSecondPredicateRegistration(descriptor => descriptor.ControllerDescriptor.ControllerType == typeof(TestController)));
+        }
+
+        [Fact]
+        public void DoesNotResolveRegisteredActionFilterForNonMatchingPredicateRegistration()
+        {
+            AssertNoFilter<TestControllerB>(
+                GetFirstRegistration(),
+                ConfigureFirstPredicateRegistration(descriptor => descriptor.ControllerDescriptor.ControllerType == typeof(TestControllerA)));
+        }
+
         protected abstract Func<IComponentContext, TFilter1> GetFirstRegistration();
 
         protected abstract Func<IComponentContext, TFilter2> GetSecondRegistration();
@@ -128,9 +191,21 @@ namespace Autofac.Integration.WebApi.Test
 
         protected abstract Action<IRegistrationBuilder<TFilter1, SimpleActivatorData, SingleRegistrationStyle>> ConfigureFirstActionRegistration();
 
+        protected abstract Action<IRegistrationBuilder<TFilter1, SimpleActivatorData, SingleRegistrationStyle>> ConfigureFirstAllControllersRegistration();
+
+        protected abstract Action<IRegistrationBuilder<TFilter1, SimpleActivatorData, SingleRegistrationStyle>> ConfigureFirstChainedControllersRegistration();
+
+        protected abstract Action<IRegistrationBuilder<TFilter1, SimpleActivatorData, SingleRegistrationStyle>> ConfigureFirstPredicateRegistration(Func<HttpActionDescriptor, bool> predicate);
+
         protected abstract Action<IRegistrationBuilder<TFilter2, SimpleActivatorData, SingleRegistrationStyle>> ConfigureSecondControllerRegistration();
 
         protected abstract Action<IRegistrationBuilder<TFilter2, SimpleActivatorData, SingleRegistrationStyle>> ConfigureSecondActionRegistration();
+
+        protected abstract Action<IRegistrationBuilder<TFilter2, SimpleActivatorData, SingleRegistrationStyle>> ConfigureSecondAllControllersRegistration();
+
+        protected abstract Action<IRegistrationBuilder<TFilter2, SimpleActivatorData, SingleRegistrationStyle>> ConfigureSecondChainedControllersRegistration();
+
+        protected abstract Action<IRegistrationBuilder<TFilter2, SimpleActivatorData, SingleRegistrationStyle>> ConfigureSecondPredicateRegistration(Func<HttpActionDescriptor, bool> predicate);
 
         protected abstract Type GetWrapperType();
 
@@ -173,6 +248,25 @@ namespace Autofac.Integration.WebApi.Test
             var wrapperType = GetWrapperType();
             var filter = filterInfos.Select(info => info.Instance).Single(i => i.GetType() == wrapperType);
             Assert.IsType(wrapperType, filter);
+        }
+
+        private void AssertNoFilter<TController>(
+            Func<IComponentContext, TFilter1> registration,
+            Action<IRegistrationBuilder<TFilter1, SimpleActivatorData, SingleRegistrationStyle>> configure)
+        {
+            var builder = new ContainerBuilder();
+            builder.Register<ILogger>(c => new Logger()).InstancePerDependency();
+            configure(builder.Register(registration).InstancePerRequest());
+            var container = builder.Build();
+            var provider = new AutofacWebApiFilterProvider(container);
+            var configuration = new HttpConfiguration { DependencyResolver = new AutofacWebApiDependencyResolver(container) };
+            var actionDescriptor = BuildActionDescriptorForGetMethod(typeof(TController));
+
+            var filterInfos = provider.GetFilters(configuration, actionDescriptor).ToArray();
+
+            var wrapperType = GetWrapperType();
+            var filterApplied = filterInfos.Select(info => info.Instance).Any(i => i.GetType() == wrapperType);
+            Assert.False(filterApplied);
         }
 
         private void AssertMultipleFilters(
@@ -233,6 +327,69 @@ namespace Autofac.Integration.WebApi.Test
             var filters = filterInfos.Select(info => info.Instance).Where(i => i.GetType() == wrapperType).ToArray();
             Assert.Single(filters);
             Assert.IsType(wrapperType, filters[0]);
+        }
+
+        private void AssertMultiControllerRegistration<TController1, TController2>(
+            Func<IComponentContext, TFilter1> registration,
+            Action<IRegistrationBuilder<TFilter1, SimpleActivatorData, SingleRegistrationStyle>> configure)
+        {
+            var builder = new ContainerBuilder();
+            builder.Register<ILogger>(c => new Logger()).InstancePerDependency();
+            configure(builder.Register(registration).InstancePerRequest());
+            var container = builder.Build();
+            var provider = new AutofacWebApiFilterProvider(container);
+            var configuration = new HttpConfiguration { DependencyResolver = new AutofacWebApiDependencyResolver(container) };
+
+            var wrapperType = GetWrapperType();
+
+            var firstActionDescriptor = BuildActionDescriptorForGetMethod(typeof(TController1));
+
+            var firstControllerFilters = provider.GetFilters(configuration, firstActionDescriptor).ToArray();
+
+            var firstFilter = firstControllerFilters.Select(info => info.Instance).Single(i => i.GetType() == wrapperType);
+
+            Assert.IsType(wrapperType, firstFilter);
+
+            var secondActionDescriptor = BuildActionDescriptorForGetMethod(typeof(TController2));
+
+            var secondControllerFilters = provider.GetFilters(configuration, secondActionDescriptor).ToArray();
+
+            var secondFilter = secondControllerFilters.Select(info => info.Instance).Single(i => i.GetType() == wrapperType);
+
+            Assert.IsType(wrapperType, secondFilter);
+        }
+
+        private void AssertMultiControllerRegistration<TController1, TController2>(
+            Func<IComponentContext, TFilter1> registration1,
+            Func<IComponentContext, TFilter2> registration2,
+            Action<IRegistrationBuilder<TFilter1, SimpleActivatorData, SingleRegistrationStyle>> configure1,
+            Action<IRegistrationBuilder<TFilter2, SimpleActivatorData, SingleRegistrationStyle>> configure2)
+        {
+            var builder = new ContainerBuilder();
+            builder.Register<ILogger>(c => new Logger()).InstancePerDependency();
+            configure1(builder.Register(registration1).InstancePerRequest());
+            configure2(builder.Register(registration2).InstancePerRequest());
+            var container = builder.Build();
+            var provider = new AutofacWebApiFilterProvider(container);
+            var configuration = new HttpConfiguration { DependencyResolver = new AutofacWebApiDependencyResolver(container) };
+
+            var wrapperType = GetWrapperType();
+
+            var firstActionDescriptor = BuildActionDescriptorForGetMethod(typeof(TController1));
+
+            var firstControllerFilters = provider.GetFilters(configuration, firstActionDescriptor).ToArray();
+
+            var firstFilter = firstControllerFilters.Select(info => info.Instance).Single(i => i.GetType() == wrapperType);
+
+            Assert.IsType(wrapperType, firstFilter);
+
+            var secondActionDescriptor = BuildActionDescriptorForGetMethod(typeof(TController2));
+
+            var secondControllerFilters = provider.GetFilters(configuration, secondActionDescriptor).ToArray();
+
+            var secondFilter = secondControllerFilters.Select(info => info.Instance).Single(i => i.GetType() == wrapperType);
+
+            Assert.IsType(wrapperType, secondFilter);
         }
     }
 }

--- a/test/Autofac.Integration.WebApi.Test/ExceptionFilterFixture.cs
+++ b/test/Autofac.Integration.WebApi.Test/ExceptionFilterFixture.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Web.Http.Controllers;
 using System.Web.Http.Filters;
 using Autofac.Builder;
 using Autofac.Integration.WebApi;
@@ -28,6 +29,22 @@ namespace Autofac.Integration.WebApi.Test
             return r => r.AsWebApiExceptionFilterFor<TestController>(c => c.Get());
         }
 
+        protected override Action<IRegistrationBuilder<TestExceptionFilter, SimpleActivatorData, SingleRegistrationStyle>> ConfigureFirstAllControllersRegistration()
+        {
+            return r => r.AsWebApiExceptionFilterForAllControllers();
+        }
+
+        protected override Action<IRegistrationBuilder<TestExceptionFilter, SimpleActivatorData, SingleRegistrationStyle>> ConfigureFirstChainedControllersRegistration()
+        {
+            return r => r.AsWebApiExceptionFilterFor<TestControllerA>()
+                         .AsWebApiExceptionFilterFor<TestControllerB>();
+        }
+
+        protected override Action<IRegistrationBuilder<TestExceptionFilter, SimpleActivatorData, SingleRegistrationStyle>> ConfigureFirstPredicateRegistration(Func<HttpActionDescriptor, bool> predicate)
+        {
+            return r => r.AsWebApiExceptionFilterWhere(predicate);
+        }
+
         protected override Action<IRegistrationBuilder<TestExceptionFilter2, SimpleActivatorData, SingleRegistrationStyle>> ConfigureSecondControllerRegistration()
         {
             return r => r.AsWebApiExceptionFilterFor<TestController>();
@@ -36,6 +53,22 @@ namespace Autofac.Integration.WebApi.Test
         protected override Action<IRegistrationBuilder<TestExceptionFilter2, SimpleActivatorData, SingleRegistrationStyle>> ConfigureSecondActionRegistration()
         {
             return r => r.AsWebApiExceptionFilterFor<TestController>(c => c.Get());
+        }
+
+        protected override Action<IRegistrationBuilder<TestExceptionFilter2, SimpleActivatorData, SingleRegistrationStyle>> ConfigureSecondAllControllersRegistration()
+        {
+            return r => r.AsWebApiExceptionFilterForAllControllers();
+        }
+
+        protected override Action<IRegistrationBuilder<TestExceptionFilter2, SimpleActivatorData, SingleRegistrationStyle>> ConfigureSecondChainedControllersRegistration()
+        {
+            return r => r.AsWebApiExceptionFilterFor<TestControllerA>()
+                .AsWebApiExceptionFilterFor<TestControllerB>();
+        }
+
+        protected override Action<IRegistrationBuilder<TestExceptionFilter2, SimpleActivatorData, SingleRegistrationStyle>> ConfigureSecondPredicateRegistration(Func<HttpActionDescriptor, bool> predicate)
+        {
+            return r => r.AsWebApiExceptionFilterWhere(predicate);
         }
 
         protected override Type GetWrapperType()

--- a/test/Autofac.Integration.WebApi.Test/ExceptionFilterFixture.cs
+++ b/test/Autofac.Integration.WebApi.Test/ExceptionFilterFixture.cs
@@ -40,7 +40,7 @@ namespace Autofac.Integration.WebApi.Test
                          .AsWebApiExceptionFilterFor<TestControllerB>();
         }
 
-        protected override Action<IRegistrationBuilder<TestExceptionFilter, SimpleActivatorData, SingleRegistrationStyle>> ConfigureFirstPredicateRegistration(Func<HttpActionDescriptor, bool> predicate)
+        protected override Action<IRegistrationBuilder<TestExceptionFilter, SimpleActivatorData, SingleRegistrationStyle>> ConfigureFirstPredicateRegistration(Func<ILifetimeScope, HttpActionDescriptor, bool> predicate)
         {
             return r => r.AsWebApiExceptionFilterWhere(predicate);
         }

--- a/test/Autofac.Integration.WebApi.Test/ExceptionFilterOverrideWrapperFixture.cs
+++ b/test/Autofac.Integration.WebApi.Test/ExceptionFilterOverrideWrapperFixture.cs
@@ -1,4 +1,5 @@
-﻿using System.Web.Http.Filters;
+﻿using System.Collections.Generic;
+using System.Web.Http.Filters;
 using Xunit;
 
 namespace Autofac.Integration.WebApi.Test
@@ -6,16 +7,9 @@ namespace Autofac.Integration.WebApi.Test
     public class ExceptionFilterOverrideWrapperFixture
     {
         [Fact]
-        public void MetadataKeyReturnsOverrideValue()
-        {
-            var wrapper = new ExceptionFilterOverrideWrapper(new FilterMetadata());
-            Assert.Equal(AutofacWebApiFilterProvider.ExceptionFilterOverrideMetadataKey, wrapper.MetadataKey);
-        }
-
-        [Fact]
         public void FiltersToOverrideReturnsCorrectType()
         {
-            var wrapper = new ExceptionFilterOverrideWrapper(new FilterMetadata());
+            var wrapper = new ExceptionFilterOverrideWrapper(new HashSet<FilterMetadata>());
             Assert.Equal(typeof(IExceptionFilter), wrapper.FiltersToOverride);
         }
     }

--- a/test/Autofac.Integration.WebApi.Test/FilterMetadataExtensions.cs
+++ b/test/Autofac.Integration.WebApi.Test/FilterMetadataExtensions.cs
@@ -1,5 +1,5 @@
 ﻿// This software is part of the Autofac IoC container
-// Copyright (c) 2013 Autofac Contributors
+// Copyright (c) 2012 Autofac Contributors
 // https://autofac.org
 //
 // Permission is hereby granted, free of charge, to any person
@@ -23,16 +23,34 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
-namespace Autofac.Integration.WebApi
+using System.Collections.Generic;
+using Autofac.Builder;
+using Xunit;
+
+namespace Autofac.Integration.WebApi.Test
 {
-    /// <summary>
-    /// Common behaviour required for filter wrappers.
-    /// </summary>
-    internal interface IFilterWrapper
+    internal static class FilterMetadataExtensions
     {
+        public static HashSet<FilterMetadata> ToSingleFilterHashSet(this FilterMetadata metadata)
+        {
+            return new HashSet<FilterMetadata> { metadata };
+        }
+
         /// <summary>
-        /// Gets the metadata key used to retrieve the filter metadata.
+        /// Retrieve or create filter metadata. We want to maintain the fluent flow when we change
+        /// registration metadata so we'll do that here.
         /// </summary>
-        string MetadataKey { get; }
+        public static IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> GetMetadata(
+            this IRegistrationBuilder<object, IConcreteActivatorData, SingleRegistrationStyle> registration,
+            out FilterMetadata filterMeta)
+        {
+            Assert.True(registration.RegistrationData.Metadata.TryGetValue(AutofacWebApiFilterProvider.FilterMetadataKey, out var filterDataObj));
+
+            filterMeta = (FilterMetadata)filterDataObj;
+
+            Assert.NotNull(filterMeta);
+
+            return registration;
+        }
     }
 }

--- a/test/Autofac.Integration.WebApi.Test/FilterOrderingFixture.cs
+++ b/test/Autofac.Integration.WebApi.Test/FilterOrderingFixture.cs
@@ -94,16 +94,16 @@ namespace Autofac.Integration.WebApi.Test
             var actionExecutedContext = new HttpActionExecutedContext(actionContext, null);
             var token = new CancellationTokenSource().Token;
 
+            foreach (var fi in filterInfos.Select(f => f.Instance).OfType<IAuthenticationFilter>())
+            {
+                await fi.AuthenticateAsync(authnContext, token);
+            }
+
             // Loop through each type of filter in the order Web API would
             // do it. This will give us the complete list of filters.
             foreach (var fi in filterInfos.Select(f => f.Instance).OfType<AuthorizationFilterAttribute>())
             {
                 await fi.OnAuthorizationAsync(actionContext, token);
-            }
-
-            foreach (var fi in filterInfos.Select(f => f.Instance).OfType<IAuthenticationFilter>())
-            {
-                await fi.AuthenticateAsync(authnContext, token);
             }
 
             foreach (var fi in filterInfos.Select(f => f.Instance).OfType<ActionFilterAttribute>())
@@ -123,15 +123,6 @@ namespace Autofac.Integration.WebApi.Test
             // - Action scoped filters
             var expectedOrder = new Type[]
             {
-                typeof(OrderTestAuthorizationFilter<D>),
-                typeof(OrderTestAuthorizationFilter<B>),
-                typeof(OrderTestAuthorizationFilter<H>),
-                typeof(OrderTestAuthorizationFilter<F>),
-                typeof(OrderTestAuthorizationFilter<C>),
-                typeof(OrderTestAuthorizationFilter<A>),
-                typeof(OrderTestAuthorizationFilter<G>),
-                typeof(OrderTestAuthorizationFilter<E>),
-
                 typeof(OrderTestAuthenticationFilter<D>),
                 typeof(OrderTestAuthenticationFilter<B>),
                 typeof(OrderTestAuthenticationFilter<H>),
@@ -140,6 +131,15 @@ namespace Autofac.Integration.WebApi.Test
                 typeof(OrderTestAuthenticationFilter<A>),
                 typeof(OrderTestAuthenticationFilter<G>),
                 typeof(OrderTestAuthenticationFilter<E>),
+
+                typeof(OrderTestAuthorizationFilter<D>),
+                typeof(OrderTestAuthorizationFilter<B>),
+                typeof(OrderTestAuthorizationFilter<H>),
+                typeof(OrderTestAuthorizationFilter<F>),
+                typeof(OrderTestAuthorizationFilter<C>),
+                typeof(OrderTestAuthorizationFilter<A>),
+                typeof(OrderTestAuthorizationFilter<G>),
+                typeof(OrderTestAuthorizationFilter<E>),
 
                 typeof(OrderTestActionFilter<D>),
                 typeof(OrderTestActionFilter<B>),

--- a/test/Autofac.Integration.WebApi.Test/RegistrationExtensionsFixture.cs
+++ b/test/Autofac.Integration.WebApi.Test/RegistrationExtensionsFixture.cs
@@ -28,6 +28,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Web.Http;
+using System.Web.Http.Controllers;
 using System.Web.Http.Filters;
 using System.Web.Http.ModelBinding;
 using Autofac.Builder;
@@ -270,7 +271,7 @@ namespace Autofac.Integration.WebApi.Test
             var exception = Assert.Throws<InvalidEnumArgumentException>(
                 () => builder.Register(c => new TestActionFilter(c.Resolve<ILogger>())).AsWebApiActionFilterWhere(descriptor => true, FilterScope.Global));
 
-            Assert.Equal("scope", exception.ParamName);
+            Assert.Equal("filterScope", exception.ParamName);
         }
 
         [Fact]
@@ -289,7 +290,7 @@ namespace Autofac.Integration.WebApi.Test
         {
             var builder = new ContainerBuilder();
             var exception = Assert.Throws<ArgumentNullException>(
-                () => builder.Register(c => new TestActionFilter(c.Resolve<ILogger>())).AsWebApiActionFilterWhere(null));
+                () => builder.Register(c => new TestActionFilter(c.Resolve<ILogger>())).AsWebApiActionFilterWhere((Func<ILifetimeScope, HttpActionDescriptor, bool>)null));
             Assert.Equal("predicate", exception.ParamName);
         }
 
@@ -318,7 +319,8 @@ namespace Autofac.Integration.WebApi.Test
         {
             var builder = new ContainerBuilder();
             var exception = Assert.Throws<ArgumentNullException>(
-                () => builder.Register(c => new TestActionFilter(c.Resolve<ILogger>())).AsWebApiAuthorizationFilterWhere(null));
+                () => builder.Register(c => new TestActionFilter(c.Resolve<ILogger>()))
+                             .AsWebApiAuthorizationFilterWhere((Func<ILifetimeScope, HttpActionDescriptor, bool>)null));
             Assert.Equal("predicate", exception.ParamName);
         }
 
@@ -336,7 +338,8 @@ namespace Autofac.Integration.WebApi.Test
         {
             var builder = new ContainerBuilder();
             var exception = Assert.Throws<ArgumentNullException>(
-                () => builder.Register(c => new TestActionFilter(c.Resolve<ILogger>())).AsWebApiExceptionFilterWhere(null));
+                () => builder.Register(c => new TestActionFilter(c.Resolve<ILogger>()))
+                             .AsWebApiExceptionFilterWhere((Func<ILifetimeScope, HttpActionDescriptor, bool>)null));
             Assert.Equal("predicate", exception.ParamName);
         }
 
@@ -365,7 +368,8 @@ namespace Autofac.Integration.WebApi.Test
         {
             var builder = new ContainerBuilder();
             var exception = Assert.Throws<ArgumentNullException>(
-                () => builder.Register(c => new TestActionFilter(c.Resolve<ILogger>())).AsWebApiAuthorizationFilterWhere(null));
+                () => builder.Register(c => new TestActionFilter(c.Resolve<ILogger>()))
+                             .AsWebApiAuthorizationFilterWhere((Func<ILifetimeScope, HttpActionDescriptor, bool>)null));
             Assert.Equal("predicate", exception.ParamName);
         }
 

--- a/test/Autofac.Integration.WebApi.Test/RegistrationExtensionsFixture.cs
+++ b/test/Autofac.Integration.WebApi.Test/RegistrationExtensionsFixture.cs
@@ -24,9 +24,11 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Web.Http;
+using System.Web.Http.Filters;
 using System.Web.Http.ModelBinding;
 using Autofac.Builder;
 using Autofac.Integration.WebApi.Test.TestTypes;
@@ -250,6 +252,48 @@ namespace Autofac.Integration.WebApi.Test
         }
 
         [Fact]
+        public void AsActionFilterForPredicateMustBeActionFilter()
+        {
+            var builder = new ContainerBuilder();
+
+            var exception = Assert.Throws<ArgumentException>(
+                () => builder.RegisterInstance(new object()).AsWebApiActionFilterWhere(descriptor => true));
+
+            Assert.Equal("registration", exception.ParamName);
+        }
+
+        [Fact]
+        public void AsActionFilterForPredicateNoGlobalScope()
+        {
+            var builder = new ContainerBuilder();
+
+            var exception = Assert.Throws<InvalidEnumArgumentException>(
+                () => builder.Register(c => new TestActionFilter(c.Resolve<ILogger>())).AsWebApiActionFilterWhere(descriptor => true, FilterScope.Global));
+
+            Assert.Equal("scope", exception.ParamName);
+        }
+
+        [Fact]
+        public void AsActionFilterForAllControllersMustBeActionFilter()
+        {
+            var builder = new ContainerBuilder();
+
+            var exception = Assert.Throws<ArgumentException>(
+                () => builder.RegisterInstance(new object()).AsWebApiActionFilterForAllControllers());
+
+            Assert.Equal("registration", exception.ParamName);
+        }
+
+        [Fact]
+        public void AsActionFilterWhereRequiresPredicate()
+        {
+            var builder = new ContainerBuilder();
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => builder.Register(c => new TestActionFilter(c.Resolve<ILogger>())).AsWebApiActionFilterWhere(null));
+            Assert.Equal("predicate", exception.ParamName);
+        }
+
+        [Fact]
         public void AsAuthorizationFilterForRequiresActionSelector()
         {
             var builder = new ContainerBuilder();
@@ -270,12 +314,30 @@ namespace Autofac.Integration.WebApi.Test
         }
 
         [Fact]
+        public void AsAuthorizationFilterWhereRequiresPredicate()
+        {
+            var builder = new ContainerBuilder();
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => builder.Register(c => new TestActionFilter(c.Resolve<ILogger>())).AsWebApiAuthorizationFilterWhere(null));
+            Assert.Equal("predicate", exception.ParamName);
+        }
+
+        [Fact]
         public void AsExceptionFilterForRequiresActionSelector()
         {
             var builder = new ContainerBuilder();
             var exception = Assert.Throws<ArgumentNullException>(
                 () => builder.Register(c => new TestExceptionFilter(c.Resolve<ILogger>())).AsWebApiExceptionFilterFor<TestController>(null));
             Assert.Equal("actionSelector", exception.ParamName);
+        }
+
+        [Fact]
+        public void AsExceptionFilterWhereRequiresPredicate()
+        {
+            var builder = new ContainerBuilder();
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => builder.Register(c => new TestActionFilter(c.Resolve<ILogger>())).AsWebApiExceptionFilterWhere(null));
+            Assert.Equal("predicate", exception.ParamName);
         }
 
         [Fact]
@@ -296,6 +358,15 @@ namespace Autofac.Integration.WebApi.Test
             var exception = Assert.Throws<ArgumentNullException>(
                 () => builder.Register(c => new TestAuthenticationFilter(c.Resolve<ILogger>())).AsWebApiAuthenticationFilterFor<TestController>(null));
             Assert.Equal("actionSelector", exception.ParamName);
+        }
+
+        [Fact]
+        public void AsAuthenticationFilterWhereRequiresPredicate()
+        {
+            var builder = new ContainerBuilder();
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => builder.Register(c => new TestActionFilter(c.Resolve<ILogger>())).AsWebApiAuthorizationFilterWhere(null));
+            Assert.Equal("predicate", exception.ParamName);
         }
 
         [Fact]

--- a/test/Autofac.Integration.WebApi.Test/TestTypes/TestAuthenticationFilter.cs
+++ b/test/Autofac.Integration.WebApi.Test/TestTypes/TestAuthenticationFilter.cs
@@ -46,11 +46,13 @@ namespace Autofac.Integration.WebApi.Test.TestTypes
 
         public Task AuthenticateAsync(HttpAuthenticationContext context, CancellationToken cancellationToken)
         {
+            Logger.Log(nameof(AuthenticateAsync));
             return Task.FromResult(0);
         }
 
         public Task ChallengeAsync(HttpAuthenticationChallengeContext context, CancellationToken cancellationToken)
         {
+            Logger.Log(nameof(ChallengeAsync));
             return Task.FromResult(0);
         }
     }


### PR DESCRIPTION
This change is a fairly large overhaul of the way filters are registered and executed in the WebApi integration to move to a predicate-based system that closes #17 and closes #9.

As far as I can tell though, there are no breaking API or behaviour changes.

Filter registration becomes a lot more powerful, with the ability to chain any number of controller attachments to a single filter registration:

```
 builder.Register(s => new MyActionFilter())
        .AsWebApiActionFilterFor<TestController>(con => con.Index())
        .AsWebApiActionFilterFor<TestController>(con => con.Get())
        .AsWebApiActionFilterFor<TestController2>();
```

There is now an 'All Controllers' variant:

```
 builder.Register(s => new MyAuthorizationFilter())
        .AsWebApiAuthorizationFilterForAllControllers();
```

Plus the ability to directly define your own predicate:

```

 builder.Register(s => new MyAuthenticationFilter())
        .AsWebApiAuthenticationFilterWhere(action => action.ActionName.IndexOf("api") != -1);
            
```

The predicate has access to the metadata lifetime scope (optionally in the ``*Where`` registration extensions):

```

 builder.Register(s => new MyExceptionFilter())
        .AsWebApiExceptionFilterWhere((scope, action) => {
            var filterConfig = scope.Resolve<IFilterConfig>();           
            return action.ActionName.IndexOf(filterConfig.ActionMatch) != -1
        });
            
```

As an overview of the actual code changes:

- The filter matching is now switched to a predicate-based model, with the predicates defined at registration time. 

- The previous metadata keys separated by filter 'stage' are gone; instead there is a single metadata key for filter metadata, and each subsequent ``As*`` method in the registration appends to the existing set for the filter.

- Each predicate has an associated ``AutofacFilterCategory``, which replaces the old metadata keys, and a ``FilterScope``, which is the normal WebApi filter scope.

- The predicates are only executed once per action, in the `AutofacWebApiFilterProvider` (so it's safe to do reflection and whatever is needed here). I didn't want to run potentially expensive predicates for every action invoke if I could avoid it.

- The ``AutofacWebApiFilterProvider`` builds a ``HashSet`` of the filter registrations that are required for a given ``AutofacFilterCategory`` and ``FilterScope`` and constructs a filter wrapper class passing that set. When the wrappers resolve their filters, they just check if each filter registration is present in their ``HashSet``.

One point I would like feedback on (and happy for advice one way or another) is that I am allocating a new ``Guid`` for each distinct filter registration in ``FilterMetadata`` so I have a proper unique ID for the ``HashSet`` later on; I did notice that ``SingleRegistrationStyle`` has a ``Guid`` id that I believe is also per-registration, but I was reluctant to couple the registration process to the ``SingleRegistrationStyle``? Was that the correct choice or should I re-use that ID to save the registration-time cost of allocating a new ``Guid``?
