### PR TITLE
Correctly check for filters on base controllers

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
-  package_semantic_version: 4.3.0
-  assembly_semantic_version: 4.3.0
+  package_semantic_version: 4.3.1
+  assembly_semantic_version: 4.3.1
 
 version: $(package_semantic_version).{build}
 

--- a/src/Autofac.Integration.WebApi/RegistrationExtensions.cs
+++ b/src/Autofac.Integration.WebApi/RegistrationExtensions.cs
@@ -1003,7 +1003,7 @@ namespace Autofac.Integration.WebApi
             {
                 Scope = FilterScope.Controller,
                 FilterCategory = filterCategory,
-                Predicate = (scope, descriptor) => descriptor.ControllerDescriptor.ControllerType == typeof(TController)
+                Predicate = (scope, descriptor) => typeof(TController).IsAssignableFrom(descriptor.ControllerDescriptor.ControllerType)
             };
 
             filterMeta.PredicateSet.Add(registrationMetadata);
@@ -1026,7 +1026,7 @@ namespace Autofac.Integration.WebApi
             {
                 Scope = FilterScope.Controller,
                 FilterCategory = filterCategory,
-                Predicate = (scope, descriptor) => descriptor.ControllerDescriptor.ControllerType == typeof(TController)
+                Predicate = (scope, descriptor) => typeof(TController).IsAssignableFrom(descriptor.ControllerDescriptor.ControllerType)
             };
 
             filterMeta.PredicateSet.Add(registrationMetadata);

--- a/test/Autofac.Integration.WebApi.Test/AutofacFilterBaseFixture.cs
+++ b/test/Autofac.Integration.WebApi.Test/AutofacFilterBaseFixture.cs
@@ -21,6 +21,22 @@ namespace Autofac.Integration.WebApi.Test
         }
 
         [Fact]
+        public void ResolvesControllerScopedFilterForImmediateBaseController()
+        {
+            AssertSingleFilter<TestControllerA>(
+                GetFirstRegistration(),
+                ConfigureFirstControllerRegistration());
+        }
+
+        [Fact]
+        public void ResolvesControllerScopedFilterForMostBaseController()
+        {
+            AssertSingleFilter<TestControllerB>(
+                GetFirstRegistration(),
+                ConfigureFirstActionRegistration());
+        }
+
+        [Fact]
         public void ResolvesActionScopedFilter()
         {
             AssertSingleFilter<TestController>(


### PR DESCRIPTION
Added the tests for the only part of derived controller behaviour that _isn't_ covered by unit tests, the simple controller registration type without an override.

Applied the correct type checking in the remaining method.