### PR TITLE
Autofac v5 upgrade

### DIFF
--- a/src/Autofac.Integration.WebApi/Autofac.Integration.WebApi.csproj
+++ b/src/Autofac.Integration.WebApi/Autofac.Integration.WebApi.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Autofac.Integration.WebApi</RootNamespace>
     <AssemblyName>Autofac.Integration.WebApi</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\Autofac.snk</AssemblyOriginatorKeyFile>
     <FileAlignment>512</FileAlignment>
@@ -107,7 +107,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Autofac">
-      <Version>4.0.1</Version>
+      <Version>5.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNet.WebApi.Core">
       <Version>5.2.0</Version>

--- a/src/Autofac.Integration.WebApi/Autofac.Integration.WebApi.nuspec
+++ b/src/Autofac.Integration.WebApi/Autofac.Integration.WebApi.nuspec
@@ -14,12 +14,12 @@
     <iconUrl>https://cloud.githubusercontent.com/assets/1156571/13684110/16b8f152-e6bf-11e5-84ae-22c66c6d351a.png</iconUrl>
     <releaseNotes>Release notes are at https://github.com/autofac/Autofac.WebApi/releases</releaseNotes>
     <dependencies>
-      <dependency id="Autofac" version="[4.0.1,5.0.0)" />
+      <dependency id="Autofac" version="[5.0.0,6.0.0)" />
       <dependency id="Microsoft.AspNet.WebApi.Core" version="[5.2.0,6.0.0)" />
     </dependencies>
   </metadata>
   <files>
     <!-- Workaround to get PDB in package for SourceLink until we move to dotnet cli build -->
-    <file src="bin\$configuration$\$id$.pdb" target="lib\net45\" />
+    <file src="bin\$configuration$\$id$.pdb" target="lib\net461\" />
   </files>
 </package>

--- a/test/Autofac.Integration.WebApi.Test/Autofac.Integration.WebApi.Test.csproj
+++ b/test/Autofac.Integration.WebApi.Test/Autofac.Integration.WebApi.Test.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Autofac.Integration.WebApi.Test</RootNamespace>
     <AssemblyName>Autofac.Integration.WebApi.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NoWarn>$(NoWarn);CS1591;SA1602;SA1611;CA1812</NoWarn>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
@@ -126,7 +126,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Autofac">
-      <Version>4.0.1</Version>
+      <Version>5.0.0</Version>
     </PackageReference>
     <PackageReference Include="Castle.Core">
       <Version>4.3.1</Version>

--- a/test/Autofac.Integration.WebApi.Test/RegistrationExtensionsFixture.cs
+++ b/test/Autofac.Integration.WebApi.Test/RegistrationExtensionsFixture.cs
@@ -127,7 +127,7 @@ namespace Autofac.Integration.WebApi.Test
         [Fact]
         public void AsModelBinderForTypesThrowsExceptionForEmptyTypeList()
         {
-            var types = new Type[0];
+            var types = Array.Empty<Type>();
             var builder = new ContainerBuilder();
             var registration = builder.RegisterType<TestModelBinder>();
             Assert.Throws<ArgumentException>(() => registration.AsModelBinderForTypes(types));


### PR DESCRIPTION
Updated the package references and NuSpec constraints. No need for another appveyor version change; we haven't released 5.0 of this extension yet.