### PR TITLE
HttpRequestMessage isn't mark with ExternallyOwned

### DIFF
--- a/src/Autofac.Integration.WebApi/HttpConfigurationExtensions.cs
+++ b/src/Autofac.Integration.WebApi/HttpConfigurationExtensions.cs
@@ -54,7 +54,8 @@ namespace Autofac.Integration.WebApi
             if (config.MessageHandlers.OfType<CurrentRequestHandler>().Any()) return;
 
             builder.Register(c => HttpRequestMessageProvider.Current)
-                .InstancePerRequest();
+                .InstancePerRequest()
+                .ExternallyOwned();
 
             config.MessageHandlers.Add(new CurrentRequestHandler());
         }


### PR DESCRIPTION
Fixes: https://github.com/autofac/Autofac.WebApi/issues/59


Because the HttpRequestMessage  isn't mark with ExternallyOwned in some situation autofac dispose it