### PR TITLE
Removing finalizer from AutofacWebApiDependencyScope

### DIFF
--- a/src/Autofac.Integration.WebApi/AutofacWebApiDependencyScope.cs
+++ b/src/Autofac.Integration.WebApi/AutofacWebApiDependencyScope.cs
@@ -27,14 +27,6 @@ namespace Autofac.Integration.WebApi
         }
 
         /// <summary>
-        /// Finalizes an instance of the <see cref="AutofacWebApiDependencyScope"/> class.
-        /// </summary>
-        ~AutofacWebApiDependencyScope()
-        {
-            Dispose(false);
-        }
-
-        /// <summary>
         /// Gets the lifetime scope for the current dependency scope.
         /// </summary>
         public ILifetimeScope LifetimeScope


### PR DESCRIPTION
As we don't have any unmanaged resources to release, we don't really need finalization (see https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-dispose#implement-the-dispose-pattern, the first example, `BaseClassWithSafeHandle`).

This will fix autofac/Autofac.WebApi.Owin#15.