### PR TITLE
Fix synchronization context loss in AutofacActionFilterAdapter 

### DIFF
--- a/src/Autofac.Integration.WebApi/AutofacActionFilterAdapter.cs
+++ b/src/Autofac.Integration.WebApi/AutofacActionFilterAdapter.cs
@@ -31,9 +31,10 @@ internal class AutofacActionFilterAdapter : IAutofacContinuationActionFilter
     }
 
     /// <inheritdoc/>
+    [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "SynchronizationContext should be preserved")]
     public async Task<HttpResponseMessage> ExecuteActionFilterAsync(HttpActionContext actionContext, CancellationToken cancellationToken, Func<Task<HttpResponseMessage>> continuation)
     {
-        await _legacyFilter.OnActionExecutingAsync(actionContext, cancellationToken).ConfigureAwait(false);
+        await _legacyFilter.OnActionExecutingAsync(actionContext, cancellationToken);
 
         return actionContext.Response ?? await CallOnActionExecutedAsync(actionContext, cancellationToken, continuation).ConfigureAwait(false);
     }
@@ -44,6 +45,7 @@ internal class AutofacActionFilterAdapter : IAutofacContinuationActionFilter
     /// </summary>
     [SuppressMessage("Microsoft.CodeQuality", "CA1068", Justification = "Matching parameter order in original implementation.")]
     [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Need to capture any exception that occurs.")]
+    [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "Need to preserve the SynchronizationContext for the action execution")]
     private async Task<HttpResponseMessage> CallOnActionExecutedAsync(HttpActionContext actionContext, CancellationToken cancellationToken, Func<Task<HttpResponseMessage>> continuation)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -53,7 +55,7 @@ internal class AutofacActionFilterAdapter : IAutofacContinuationActionFilter
 
         try
         {
-            response = await continuation().ConfigureAwait(false);
+            response = await continuation();
         }
         catch (Exception e)
         {
@@ -68,7 +70,7 @@ internal class AutofacActionFilterAdapter : IAutofacContinuationActionFilter
 
         try
         {
-            await _legacyFilter.OnActionExecutedAsync(executedContext, cancellationToken).ConfigureAwait(false);
+            await _legacyFilter.OnActionExecutedAsync(executedContext, cancellationToken);
         }
         catch
         {

--- a/test/Autofac.Integration.WebApi.Test/TestTypes/RecordingSynchronizationContext.cs
+++ b/test/Autofac.Integration.WebApi.Test/TestTypes/RecordingSynchronizationContext.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Autofac.Integration.WebApi.Test.TestTypes;
+
+/// <summary>
+/// A lightweight synchronization context used in tests to execute posted work immediately
+/// while ensuring the custom context remains current across callbacks.
+/// </summary>
+public class RecordingSynchronizationContext : SynchronizationContext
+{
+    /// <summary>
+    /// Dispatches asynchronous work onto the test synchronization context and ensures the
+    /// context is restored afterwards.
+    /// </summary>
+    /// <param name="d">The callback delegate to execute.</param>
+    /// <param name="state">The optional state to provide to the callback.</param>
+    public override void Post(SendOrPostCallback d, object state)
+    {
+        if (d is null)
+        {
+            throw new ArgumentNullException(nameof(d));
+        }
+
+        var previous = Current;
+        try
+        {
+            // Ensure continuations observe the custom context while the callback runs.
+            SetSynchronizationContext(this);
+            d(state);
+        }
+        finally
+        {
+            SetSynchronizationContext(previous);
+        }
+    }
+
+    /// <summary>
+    /// Dispatches synchronous work and mirrors the behavior of <see cref="Post"/> by
+    /// restoring the original context when complete.
+    /// </summary>
+    /// <param name="d">The callback delegate to execute.</param>
+    /// <param name="state">The optional state to provide to the callback.</param>
+    public override void Send(SendOrPostCallback d, object state)
+    {
+        if (d is null)
+        {
+            throw new ArgumentNullException(nameof(d));
+        }
+
+        var previous = Current;
+        try
+        {
+            SetSynchronizationContext(this);
+            d(state);
+        }
+        finally
+        {
+            SetSynchronizationContext(previous);
+        }
+    }
+}

--- a/test/Autofac.Integration.WebApi.Test/TestTypes/TestSynchronizationContextActionFilter.cs
+++ b/test/Autofac.Integration.WebApi.Test/TestTypes/TestSynchronizationContextActionFilter.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Web.Http.Controllers;
+using System.Web.Http.Filters;
+
+namespace Autofac.Integration.WebApi.Test.TestTypes;
+
+/// <summary>
+/// An action filter that records the synchronization context before and after asynchronous
+/// continuations to confirm the custom context flows through Autofac execution pipelines.
+/// </summary>
+[SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "Test case where SynchronizationContext should be preserved in the filter")]
+public class TestSynchronizationContextActionFilter : IAutofacActionFilter
+{
+    private readonly List<SynchronizationContext> _records = new();
+
+    /// <summary>
+    /// Gets the ordered collection of synchronization contexts recorded during filter execution.
+    /// </summary>
+    public IReadOnlyList<SynchronizationContext> Records => _records;
+
+    /// <inheritdoc />
+    public async Task OnActionExecutingAsync(HttpActionContext actionContext, CancellationToken cancellationToken)
+    {
+        // Record the context before yielding to asynchronous work.
+        _records.Add(SynchronizationContext.Current);
+
+        // A minimal asynchronous delay ensures the continuation resumes and captures the context.
+        await Task.Delay(1, cancellationToken);
+
+        // Record the context again after the await to validate it has not changed.
+        _records.Add(SynchronizationContext.Current);
+    }
+
+    /// <inheritdoc />
+    public async Task OnActionExecutedAsync(HttpActionExecutedContext actionExecutedContext, CancellationToken cancellationToken)
+    {
+        // Record the context before yielding to asynchronous work.
+        _records.Add(SynchronizationContext.Current);
+
+        // A minimal asynchronous delay ensures the continuation resumes and captures the context.
+        await Task.Delay(1, cancellationToken);
+
+        // Record the context again after the await to validate it has not changed.
+        _records.Add(SynchronizationContext.Current);
+    }
+}

--- a/test/Autofac.Integration.WebApi.Test/TestTypes/TestSynchronizationContextActionFilter2.cs
+++ b/test/Autofac.Integration.WebApi.Test/TestTypes/TestSynchronizationContextActionFilter2.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Web.Http.Controllers;
+using System.Web.Http.Filters;
+
+namespace Autofac.Integration.WebApi.Test.TestTypes;
+
+/// <summary>
+/// An action filter that records the synchronization context before asynchronous continuations using
+/// ConfigureAwait(false) to confirm the custom context flows through Autofac execution pipelines.
+/// </summary>
+public class TestSynchronizationContextActionFilter2 : IAutofacActionFilter
+{
+    private readonly List<SynchronizationContext> _records = new();
+
+    /// <summary>
+    /// Gets the ordered collection of synchronization contexts recorded during filter execution.
+    /// </summary>
+    public IReadOnlyList<SynchronizationContext> Records => _records;
+
+    /// <inheritdoc />
+    public async Task OnActionExecutingAsync(HttpActionContext actionContext, CancellationToken cancellationToken)
+    {
+        // Record the context before yielding to asynchronous work.
+        _records.Add(SynchronizationContext.Current);
+
+        // A minimal asynchronous delay ensures the continuation resumes and captures the context.
+        await Task.Delay(1, cancellationToken).ConfigureAwait(false);
+
+        // Context changed, but that shouldn't affect the execution pipeline.
+    }
+
+    /// <inheritdoc />
+    public async Task OnActionExecutedAsync(HttpActionExecutedContext actionExecutedContext, CancellationToken cancellationToken)
+    {
+        // Record the context before yielding to asynchronous work.
+        _records.Add(SynchronizationContext.Current);
+
+        // A minimal asynchronous delay ensures the continuation resumes and captures the context.
+        await Task.Delay(1, cancellationToken).ConfigureAwait(false);
+
+        // Context changed, but that shouldn't affect the execution pipeline.
+    }
+}


### PR DESCRIPTION
fixes #72 

The bug reported on issue #72 was introduced by commit d8f5022a525a28b13b455ba93e5ccacb18c322df.

* Removed the ConfigureAwait(false) in AutofacActionFilterAdapter to preserve the ASP.NET synchronization context, allowing the legacy filter and action continuations to resume on the captured context.

* Added a regression test that verifies legacy action filters and the action continuation all observe the configured synchronization context throughout execution.

* Introduced a test helper filter and recording synchronization context to capture context transitions during the new regression test.