### PR TITLE
Remove unused Moq package reference

### DIFF
--- a/test/Autofac.Integration.WebApi.Test/Autofac.Integration.WebApi.Test.csproj
+++ b/test/Autofac.Integration.WebApi.Test/Autofac.Integration.WebApi.Test.csproj
@@ -15,7 +15,7 @@
     <PreserveCompilationContext>true</PreserveCompilationContext>
   </PropertyGroup>
   <ItemGroup>
-    <Using Include="Moq" />
+
     <Using Include="Xunit" />
   </ItemGroup>
   <ItemGroup>
@@ -35,7 +35,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
-    <PackageReference Include="Moq" Version="[4.16.1]" />
+
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary
- Remove unused Moq package reference and global using from test project
- Part of cross-repo effort to standardize on NSubstitute

## Test plan
- [ ] CI build passes (net472 project, cannot build locally on macOS)