### PR TITLE
Standardize build metadata and code formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,5 @@
-; EditorConfig to support per-solution formatting.
-; Use the EditorConfig VS add-in to make this work.
-; http://editorconfig.org/
-
-; This is the default for the codeline.
+# EditorConfig to support per-solution formatting.
+# http://editorconfig.org/
 root = true
 
 [*]
@@ -10,13 +7,187 @@ indent_style = space
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-; .NET Code - almost, but not exactly, the same suggestions as corefx
-; https://github.com/dotnet/corefx/blob/master/.editorconfig
+# .NET Code
 [*.cs]
 indent_size = 4
 charset = utf-8-bom
 
-; New line preferences
+# .NET project files and MSBuild - match defaults for VS
+[*.{csproj,nuspec,proj,projitems,props,shproj,targets,vbproj,vcxproj,vcxproj.filters,vsixmanifest,vsct}]
+indent_size = 2
+
+# .NET solution files - match defaults for VS
+[*.sln]
+end_of_line = crlf
+indent_style = tab
+
+# .NET XML solution files - match dotnet new sln defaults
+[*.slnx]
+indent_size = 2
+
+
+# Config - match XML and default nuget.config template
+[*.config]
+indent_size = 2
+
+# Resources - match defaults for VS
+[*.resx]
+indent_size = 2
+
+# Static analysis rulesets - match defaults for VS
+[*.ruleset]
+indent_size = 2
+
+# HTML, XML - match defaults for VS
+[*.{cshtml,html,xml}]
+indent_size = 4
+
+# JavaScript and JS mixes - match eslint settings; JSON also matches .NET Core templates
+[*.{js,json,mjs,ts,vue}]
+indent_size = 2
+
+# Markdown - match markdownlint settings
+[*.{md,markdown}]
+indent_size = 2
+
+# PowerShell - match defaults for New-ModuleManifest and PSScriptAnalyzer Invoke-Formatter
+[*.{ps1,psd1,psm1}]
+indent_size = 4
+charset = utf-8-bom
+
+# YAML - match standard YAML like Kubernetes and GitHub Actions
+[*.{yaml,yml}]
+indent_size = 2
+
+# ReStructuredText - standard indentation format from examples
+[*.rst]
+indent_size = 2
+
+#
+# dotnet code style
+#
+[*.cs]
+
+# Sort using and Import directives with System.* appearing first
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
+
+# Avoid this. unless absolutely necessary
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+# Use language keywords instead of framework type names for type references
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+dotnet_style_predefined_type_for_member_access = true:warning
+
+# Suggest more modern language features when available
+dotnet_style_object_initializer = true:warning
+dotnet_style_collection_initializer = true:warning
+dotnet_style_coalesce_expression = true:warning
+dotnet_style_null_propagation = true:warning
+dotnet_style_explicit_tuple_names = true:warning
+
+# Whitespace options
+dotnet_style_allow_multiple_blank_lines_experimental = false
+
+# Non-private static fields are PascalCase
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.severity = warning
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.symbols = non_private_static_fields
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.style = non_private_static_field_style
+
+dotnet_naming_symbols.non_private_static_fields.applicable_kinds = field
+dotnet_naming_symbols.non_private_static_fields.applicable_accessibilities = public, protected, internal, protected_internal, private_protected
+dotnet_naming_symbols.non_private_static_fields.required_modifiers = static
+
+dotnet_naming_style.non_private_static_field_style.capitalization = pascal_case
+
+# Non-private readonly fields are PascalCase
+dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.severity = warning
+dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.symbols = non_private_readonly_fields
+dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.style = non_private_readonly_field_style
+
+dotnet_naming_symbols.non_private_readonly_fields.applicable_kinds = field
+dotnet_naming_symbols.non_private_readonly_fields.applicable_accessibilities = public, protected, internal, protected_internal, private_protected
+dotnet_naming_symbols.non_private_readonly_fields.required_modifiers = readonly
+
+dotnet_naming_style.non_private_readonly_field_style.capitalization = pascal_case
+
+# Constants are PascalCase
+dotnet_naming_rule.constants_should_be_pascal_case.severity = warning
+dotnet_naming_rule.constants_should_be_pascal_case.symbols = constants
+dotnet_naming_rule.constants_should_be_pascal_case.style = constant_style
+
+dotnet_naming_symbols.constants.applicable_kinds = field, local
+dotnet_naming_symbols.constants.required_modifiers = const
+
+dotnet_naming_style.constant_style.capitalization = pascal_case
+
+# Static fields should be _camelCase
+dotnet_naming_rule.static_fields_should_be_camel_case.severity = warning
+dotnet_naming_rule.static_fields_should_be_camel_case.symbols  = static_fields
+dotnet_naming_rule.static_fields_should_be_camel_case.style    = camel_case_underscore_style
+dotnet_naming_symbols.static_fields.applicable_kinds   = field
+dotnet_naming_symbols.static_fields.required_modifiers = static
+
+dotnet_naming_style.static_field_style.capitalization = camel_case
+
+# Instance fields are camelCase and start with _
+dotnet_naming_rule.instance_fields_should_be_camel_case.severity = warning
+dotnet_naming_rule.instance_fields_should_be_camel_case.symbols = instance_fields
+dotnet_naming_rule.instance_fields_should_be_camel_case.style = instance_field_style
+
+dotnet_naming_symbols.instance_fields.applicable_kinds = field
+
+dotnet_naming_style.instance_field_style.capitalization = camel_case
+dotnet_naming_style.instance_field_style.required_prefix = _
+
+# Locals and parameters are camelCase
+dotnet_naming_rule.locals_should_be_camel_case.severity = warning
+dotnet_naming_rule.locals_should_be_camel_case.symbols = locals_and_parameters
+dotnet_naming_rule.locals_should_be_camel_case.style = camel_case_style
+
+dotnet_naming_symbols.locals_and_parameters.applicable_kinds = parameter, local
+
+dotnet_naming_style.camel_case_style.capitalization = camel_case
+
+# Local functions are PascalCase
+dotnet_naming_rule.local_functions_should_be_pascal_case.severity = warning
+dotnet_naming_rule.local_functions_should_be_pascal_case.symbols = local_functions
+dotnet_naming_rule.local_functions_should_be_pascal_case.style = local_function_style
+
+dotnet_naming_symbols.local_functions.applicable_kinds = local_function
+
+dotnet_naming_style.local_function_style.capitalization = pascal_case
+
+# By default, name items with PascalCase
+dotnet_naming_rule.members_should_be_pascal_case.severity = warning
+dotnet_naming_rule.members_should_be_pascal_case.symbols = all_members
+dotnet_naming_rule.members_should_be_pascal_case.style = pascal_case_style
+
+dotnet_naming_symbols.all_members.applicable_kinds = *
+
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# IDE0035: Remove unreachable code
+dotnet_diagnostic.IDE0035.severity = warning
+
+# IDE0036: Order modifiers
+dotnet_diagnostic.IDE0036.severity = warning
+
+# IDE0043: Format string contains invalid placeholder
+dotnet_diagnostic.IDE0043.severity = warning
+
+# IDE0044: Make field readonly
+dotnet_diagnostic.IDE0044.severity = warning
+
+# IDE0055: Fix formatting
+dotnet_diagnostic.IDE0055.severity = warning
+
+# C# code style
+#
+# Newline settings
 csharp_new_line_before_open_brace = all
 csharp_new_line_before_else = true
 csharp_new_line_before_catch = true
@@ -25,90 +196,34 @@ csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
 csharp_new_line_between_query_expression_clauses = true
 
-; Indentation preferences
+# Indentation preferences
 csharp_indent_block_contents = true
 csharp_indent_braces = false
 csharp_indent_case_contents = true
 csharp_indent_case_contents_when_block = true
 csharp_indent_switch_labels = true
-csharp_indent_labels = one_less_than_current
+csharp_indent_labels = flush_left
 
-; Modifier preferences
-csharp_preferred_modifier_order = public,private,protected,internal,file,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,required,volatile,async:warning
+# Whitespace options
+# Each of the *_experimental rules has a corresponding IDE* setting.
+csharp_style_allow_embedded_statements_on_same_line_experimental = false
+dotnet_diagnostic.IDE2001.severity = warning
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = false
+dotnet_diagnostic.IDE2002.severity = warning
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = false
+dotnet_diagnostic.IDE2004.severity = warning
+csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental = false
+dotnet_diagnostic.IDE2005.severity = warning
+csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = false
+dotnet_diagnostic.IDE2006.severity = warning
 
-; Avoid this. unless absolutely necessary
-dotnet_style_qualification_for_field = false:suggestion
-dotnet_style_qualification_for_property = false:suggestion
-dotnet_style_qualification_for_method = false:suggestion
-dotnet_style_qualification_for_event = false:suggestion
+# Prefer "var" everywhere
+dotnet_diagnostic.IDE0007.severity = warning
+csharp_style_var_for_built_in_types = true:warning
+csharp_style_var_when_type_is_apparent = true:warning
+csharp_style_var_elsewhere = true:warning
 
-; Types: use keywords instead of BCL types, using var is fine.
-csharp_style_var_when_type_is_apparent = false:none
-dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
-dotnet_style_predefined_type_for_member_access = true:suggestion
-
-; Name all constant fields using PascalCase
-dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = warning
-dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
-dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
-dotnet_naming_symbols.constant_fields.applicable_kinds   = field
-dotnet_naming_symbols.constant_fields.required_modifiers = const
-dotnet_naming_style.pascal_case_style.capitalization = pascal_case
-
-; Static fields should be _camelCase
-dotnet_naming_rule.static_fields_should_be_camel_case.severity = warning
-dotnet_naming_rule.static_fields_should_be_camel_case.symbols  = static_fields
-dotnet_naming_rule.static_fields_should_be_camel_case.style    = camel_case_underscore_style
-dotnet_naming_symbols.static_fields.applicable_kinds   = field
-dotnet_naming_symbols.static_fields.required_modifiers = static
-dotnet_naming_symbols.static_fields.applicable_accessibilities = private, internal, private_protected
-
-; Static readonly fields should be PascalCase
-dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.severity = warning
-dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.symbols  = static_readonly_fields
-dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.style    = pascal_case_style
-dotnet_naming_symbols.static_readonly_fields.applicable_kinds   = field
-dotnet_naming_symbols.static_readonly_fields.required_modifiers = static, readonly
-dotnet_naming_symbols.static_readonly_fields.applicable_accessibilities = private, internal, private_protected
-
-; Internal and private fields should be _camelCase
-dotnet_naming_rule.camel_case_for_private_internal_fields.severity = warning
-dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields
-dotnet_naming_rule.camel_case_for_private_internal_fields.style    = camel_case_underscore_style
-dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
-dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
-dotnet_naming_style.camel_case_underscore_style.required_prefix = _
-dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
-
-; Code style defaults
-csharp_using_directive_placement = outside_namespace:suggestion
-dotnet_sort_system_directives_first = true
-csharp_prefer_braces = true:refactoring
-csharp_preserve_single_line_blocks = true:none
-csharp_preserve_single_line_statements = false:none
-csharp_prefer_static_local_function = true:suggestion
-csharp_prefer_simple_using_statement = false:none
-csharp_style_prefer_switch_expression = true:suggestion
-
-; Code quality
-dotnet_style_readonly_field = true:suggestion
-dotnet_code_quality_unused_parameters = non_public:suggestion
-
-; Expression-level preferences
-dotnet_style_object_initializer = true:suggestion
-dotnet_style_collection_initializer = true:suggestion
-dotnet_style_explicit_tuple_names = true:suggestion
-dotnet_style_coalesce_expression = true:suggestion
-dotnet_style_null_propagation = true:suggestion
-dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
-dotnet_style_prefer_inferred_tuple_names = true:suggestion
-dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
-dotnet_style_prefer_auto_properties = true:suggestion
-dotnet_style_prefer_conditional_expression_over_assignment = true:refactoring
-dotnet_style_prefer_conditional_expression_over_return = true:refactoring
-csharp_prefer_simple_default_expression = true:suggestion
-
-# Expression-bodied members
+# Prefer method-like constructs to have a block body
 csharp_style_expression_bodied_methods = true:refactoring
 csharp_style_expression_bodied_constructors = true:refactoring
 csharp_style_expression_bodied_operators = true:refactoring
@@ -118,20 +233,15 @@ csharp_style_expression_bodied_accessors = true:refactoring
 csharp_style_expression_bodied_lambdas = true:refactoring
 csharp_style_expression_bodied_local_functions = true:refactoring
 
-# Pattern matching
-csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
-csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
-csharp_style_inlined_variable_declaration = true:suggestion
-
-# Null checking preferences
-csharp_style_throw_expression = true:suggestion
-csharp_style_conditional_delegate_call = true:suggestion
-
-# Other features
-csharp_style_namespace_declarations = file_scoped:suggestion
-csharp_style_prefer_index_operator = false:none
-csharp_style_prefer_range_operator = false:none
-csharp_style_pattern_local_over_anonymous_function = false:none
+# Suggest more modern language features when available
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
+csharp_style_inlined_variable_declaration = true:warning
+csharp_style_throw_expression = true:warning
+csharp_style_conditional_delegate_call = true:warning
+csharp_style_prefer_extended_property_pattern = true:warning
+csharp_style_namespace_declarations = file_scoped:warning
+csharp_style_prefer_parameter_null_checking = false
 
 # Space preferences
 csharp_space_after_cast = false
@@ -157,48 +267,30 @@ csharp_space_between_method_declaration_parameter_list_parentheses = false
 csharp_space_between_parentheses = false
 csharp_space_between_square_brackets = false
 
-; .NET project files and MSBuild - match defaults for VS
-[*.{csproj,nuspec,proj,projitems,props,shproj,targets,vbproj,vcxproj,vcxproj.filters,vsixmanifest,vsct}]
-indent_size = 2
+# Blocks required
+csharp_prefer_braces = true:warning
+csharp_preserve_single_line_blocks = false
+csharp_preserve_single_line_statements = false
 
-; .NET solution files - match defaults for VS
-[*.sln]
-end_of_line = crlf
-indent_style = tab
+# IDE0011: Add braces
+csharp_prefer_braces = when_multiline:warning
+# NOTE: We need the below severity entry for Add Braces due to https://github.com/dotnet/roslyn/issues/44201
+dotnet_diagnostic.IDE0011.severity = warning
 
-; Config - match XML and default nuget.config template
-[*.config]
-indent_size = 2
+# IDE0040: Add accessibility modifiers
+dotnet_diagnostic.IDE0040.severity = warning
 
-; Resources - match defaults for VS
-[*.resx]
-indent_size = 2
+# IDE0052: Remove unread private member
+dotnet_diagnostic.IDE0052.severity = warning
 
-; Static analysis rulesets - match defaults for VS
-[*.ruleset]
-indent_size = 2
+# IDE0059: Unnecessary assignment to a value
+dotnet_diagnostic.IDE0059.severity = warning
 
-; HTML, XML - match defaults for VS
-[*.{cshtml,html,xml}]
-indent_size = 4
+# IDE0060: Remove unused parameter
+dotnet_diagnostic.IDE0060.severity = warning
 
-; JavaScript and JS mixes - match eslint settings; JSON also matches .NET Core templates
-[*.{js,json,ts,vue}]
-indent_size = 2
+# CA1012: Abstract types should not have public constructors
+dotnet_diagnostic.CA1012.severity = warning
 
-; Markdown - match markdownlint settings
-[*.{md,markdown}]
-indent_size = 2
-
-; PowerShell - match defaults for New-ModuleManifest and PSScriptAnalyzer Invoke-Formatter
-[*.{ps1,psd1,psm1}]
-indent_size = 4
-charset = utf-8-bom
-
-; ReStructuredText - standard indentation format from examples
-[*.rst]
-indent_size = 2
-
-# YAML - match standard YAML like Kubernetes and GitHub Actions
-[*.{yaml,yml}]
-indent_size = 2
+# CA1822: Make member static
+dotnet_diagnostic.CA1822.severity = warning

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: "cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b" # v5.0.0
+    rev: "3e8a8703264a2f4a69428a0aa4dcb512790b2c8c"  # frozen: v6.0.0
     hooks:
       - id: check-json
       - id: check-yaml
@@ -8,13 +8,13 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: "192ad822316c3a22fb3d3cc8aa6eafa0b8488360" # v0.45.0
+    rev: "e72a3ca1632f0b11a07d171449fe447a7ff6795e"  # frozen: v0.48.0
     hooks:
       - id: markdownlint
         args:
           - --fix
   - repo: https://github.com/tillig/json-sort-cli
-    rev: "009ab2ab49e1f2fa9d6b9dfc31009ceeca055204" # v3.0.0
+    rev: "2b7e147e0933bd30b58133b6f287e5c695ff4f0e"  # frozen: v3.0.1
     hooks:
       - id: json-sort
         args:

--- a/build/Source.ruleset
+++ b/build/Source.ruleset
@@ -26,6 +26,8 @@
     <Rule Id="CA2229" Action="None" />
     <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core. -->
     <Rule Id="CA2237" Action="None" />
+    <!-- Prefer generic overloads to using Type parameters - many aren't available in earlier frameworks; and we do a lot of reflection work in Autofac. -->
+    <Rule Id="CA2263" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <!-- Prefix local calls with this. -->

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -22,6 +22,8 @@
     <Rule Id="CA1506" Action="Warning" />
     <!-- Use ArgumentNullException.ThrowIfNull - this isn't available until we stop targeting netstandard. -->
     <Rule Id="CA1510" Action="None" />
+    <!-- Make API types internal - causes problems with tests and test assemblies. -->
+    <Rule Id="CA1515" Action="None" />
     <!-- Remove the underscores from member name - unit test scenarios may use underscores. -->
     <Rule Id="CA1707" Action="None" />
     <!-- Change names to avoid reserved word overlaps (e.g., Delegate, GetType, etc.) - too many of these in the public API, we'd break if we fixed it. -->
@@ -46,6 +48,8 @@
     <Rule Id="CA2234" Action="None" />
     <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core. -->
     <Rule Id="CA2237" Action="None" />
+    <!-- Prefer generic overloads to using Type parameters - we do a lot of reflection work in Autofac that needs to be tested. -->
+    <Rule Id="CA2263" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <!-- Prefix local calls with this. -->

--- a/build/stylecop.json
+++ b/build/stylecop.json
@@ -9,6 +9,9 @@
         "licenseName": "MIT"
       },
       "xmlHeader": false
+    },
+    "orderingRules": {
+      "usingDirectivesPlacement": "outsideNamespace"
     }
   }
 }

--- a/default.proj
+++ b/default.proj
@@ -57,8 +57,8 @@
     <Exec Command="dotnet build &quot;%(SolutionFile.FullPath)&quot; -c $(Configuration) /p:Version=$(Version)" />
   </Target>
   <Target Name="Package">
-    <MakeDir Directories="$([System.IO.Path]::Combine($(PackageDirectory),%(PublishProject.Filename)))" />
-    <Exec Command="dotnet pack &quot;%(SolutionFile.FullPath)&quot; -c $(Configuration) --output &quot;$(PackageDirectory)&quot; /p:Version=$(Version)" />
+    <MakeDir Directories="$(PackageDirectory)" />
+    <Exec Command="dotnet pack &quot;%(SourceProject.Identity)&quot; -c $(Configuration) --no-build --output &quot;$(PackageDirectory)&quot; /p:Version=$(Version)" />
   </Target>
   <Target Name="Test">
     <MakeDir Directories="$(LogDirectory)" />

--- a/src/Autofac.Integration.WebApi/AuthenticationFilterOverrideWrapper.cs
+++ b/src/Autofac.Integration.WebApi/AuthenticationFilterOverrideWrapper.cs
@@ -24,6 +24,9 @@ internal sealed class AuthenticationFilterOverrideWrapper : AuthenticationFilter
     /// </summary>
     public Type FiltersToOverride
     {
-        get { return typeof(IAuthenticationFilter); }
+        get
+        {
+            return typeof(IAuthenticationFilter);
+        }
     }
 }

--- a/src/Autofac.Integration.WebApi/AuthenticationFilterWrapper.cs
+++ b/src/Autofac.Integration.WebApi/AuthenticationFilterWrapper.cs
@@ -26,7 +26,10 @@ internal class AuthenticationFilterWrapper : IAuthenticationFilter, IAutofacAuth
     /// <inheritdoc/>
     bool IFilter.AllowMultiple
     {
-        get { return true; }
+        get
+        {
+            return true;
+        }
     }
 
     /// <inheritdoc/>

--- a/src/Autofac.Integration.WebApi/AuthorizationFilterOverrideWrapper.cs
+++ b/src/Autofac.Integration.WebApi/AuthorizationFilterOverrideWrapper.cs
@@ -25,6 +25,9 @@ internal sealed class AuthorizationFilterOverrideWrapper : AuthorizationFilterWr
     /// </summary>
     public Type FiltersToOverride
     {
-        get { return typeof(IAuthorizationFilter); }
+        get
+        {
+            return typeof(IAuthorizationFilter);
+        }
     }
 }

--- a/src/Autofac.Integration.WebApi/AutofacActionFilterAdapter.cs
+++ b/src/Autofac.Integration.WebApi/AutofacActionFilterAdapter.cs
@@ -63,7 +63,7 @@ internal class AutofacActionFilterAdapter : IAutofacContinuationActionFilter
             exceptionInfo = ExceptionDispatchInfo.Capture(e);
         }
 
-        Exception? exception = exceptionInfo?.SourceException;
+        var exception = exceptionInfo?.SourceException;
         HttpActionExecutedContext executedContext = new(actionContext, exception)
         {
             Response = response,
@@ -86,7 +86,7 @@ internal class AutofacActionFilterAdapter : IAutofacContinuationActionFilter
             return executedContext.Response;
         }
 
-        Exception newException = executedContext.Exception;
+        var newException = executedContext.Exception;
 
         if (newException != null)
         {

--- a/src/Autofac.Integration.WebApi/AutofacControllerConfigurationAttribute.cs
+++ b/src/Autofac.Integration.WebApi/AutofacControllerConfigurationAttribute.cs
@@ -60,16 +60,12 @@ public sealed class AutofacControllerConfigurationAttribute : Attribute, IContro
             return;
         }
 
-        var container = controllerDescriptor.Configuration.DependencyResolver.GetRootLifetimeScope();
-        if (container == null)
-        {
-            throw new InvalidOperationException(
+        var container = controllerDescriptor.Configuration.DependencyResolver.GetRootLifetimeScope() ?? throw new InvalidOperationException(
                 string.Format(
                     CultureInfo.CurrentCulture,
                     AutofacControllerConfigurationAttributeResources.DependencyResolverMissing,
                     nameof(AutofacWebApiDependencyResolver),
                     nameof(AutofacControllerConfigurationAttribute)));
-        }
 
         var controllerServices = controllerSettings.Services;
         var serviceKey = new ControllerTypeKey(controllerDescriptor.ControllerType);

--- a/src/Autofac.Integration.WebApi/AutofacOverrideFilter.cs
+++ b/src/Autofac.Integration.WebApi/AutofacOverrideFilter.cs
@@ -24,7 +24,10 @@ internal class AutofacOverrideFilter : IOverrideFilter
     /// <inheritdoc/>
     public bool AllowMultiple
     {
-        get { return false; }
+        get
+        {
+            return false;
+        }
     }
 
     /// <summary>

--- a/src/Autofac.Integration.WebApi/AutofacWebApiDependencyResolver.cs
+++ b/src/Autofac.Integration.WebApi/AutofacWebApiDependencyResolver.cs
@@ -47,7 +47,10 @@ public class AutofacWebApiDependencyResolver : IDependencyResolver
     /// <summary>
     /// Gets the root container provided to the dependency resolver.
     /// </summary>
-    public ILifetimeScope Container { get; }
+    public ILifetimeScope Container
+    {
+        get;
+    }
 
     /// <summary>
     /// Try to get a service of the given type.
@@ -106,10 +109,7 @@ public class AutofacWebApiDependencyResolver : IDependencyResolver
         {
             if (disposing)
             {
-                if (_rootDependencyScope != null)
-                {
-                    _rootDependencyScope.Dispose();
-                }
+                _rootDependencyScope?.Dispose();
             }
 
             _disposed = true;

--- a/src/Autofac.Integration.WebApi/AutofacWebApiDependencyScope.cs
+++ b/src/Autofac.Integration.WebApi/AutofacWebApiDependencyScope.cs
@@ -24,7 +24,10 @@ public class AutofacWebApiDependencyScope : IDependencyScope
     /// <summary>
     /// Gets the lifetime scope for the current dependency scope.
     /// </summary>
-    public ILifetimeScope LifetimeScope { get; }
+    public ILifetimeScope LifetimeScope
+    {
+        get;
+    }
 
     /// <summary>
     /// Try to get a service of the given type.
@@ -75,10 +78,7 @@ public class AutofacWebApiDependencyScope : IDependencyScope
         {
             if (disposing)
             {
-                if (LifetimeScope != null)
-                {
-                    LifetimeScope.Dispose();
-                }
+                LifetimeScope?.Dispose();
             }
 
             _disposed = true;

--- a/src/Autofac.Integration.WebApi/AutofacWebApiFilterProvider.cs
+++ b/src/Autofac.Integration.WebApi/AutofacWebApiFilterProvider.cs
@@ -283,12 +283,24 @@ public class AutofacWebApiFilterProvider : IFilterProvider
             AddedFilters = addedFilters;
         }
 
-        public ILifetimeScope LifetimeScope { get; }
+        public ILifetimeScope LifetimeScope
+        {
+            get;
+        }
 
-        public Type ControllerType { get; }
+        public Type ControllerType
+        {
+            get;
+        }
 
-        public List<FilterInfo> Filters { get; }
+        public List<FilterInfo> Filters
+        {
+            get;
+        }
 
-        public Dictionary<AutofacFilterCategory, List<FilterPredicateMetadata>> AddedFilters { get; }
+        public Dictionary<AutofacFilterCategory, List<FilterPredicateMetadata>> AddedFilters
+        {
+            get;
+        }
     }
 }

--- a/src/Autofac.Integration.WebApi/ContinuationActionFilterOverrideWrapper.cs
+++ b/src/Autofac.Integration.WebApi/ContinuationActionFilterOverrideWrapper.cs
@@ -24,6 +24,9 @@ internal sealed class ContinuationActionFilterOverrideWrapper : ContinuationActi
     /// </summary>
     public Type FiltersToOverride
     {
-        get { return typeof(IActionFilter); }
+        get
+        {
+            return typeof(IActionFilter);
+        }
     }
 }

--- a/src/Autofac.Integration.WebApi/ContinuationActionFilterWrapper.cs
+++ b/src/Autofac.Integration.WebApi/ContinuationActionFilterWrapper.cs
@@ -42,10 +42,10 @@ internal class ContinuationActionFilterWrapper : IActionFilter, IAutofacContinua
 
         var filters = lifetimeScope.Resolve<IEnumerable<Meta<Lazy<IAutofacContinuationActionFilter>>>>();
 
-        Func<Task<HttpResponseMessage>> result = continuation;
+        var result = continuation;
 
-        Func<Task<HttpResponseMessage>> ChainContinuation(Func<Task<HttpResponseMessage>> next, IAutofacContinuationActionFilter innerFilter) =>
-            () => innerFilter.ExecuteActionFilterAsync(actionContext, cancellationToken, next);
+        Func<Task<HttpResponseMessage>> ChainContinuation(Func<Task<HttpResponseMessage>> next, IAutofacContinuationActionFilter innerFilter)
+            => () => innerFilter.ExecuteActionFilterAsync(actionContext, cancellationToken, next);
 
         // We go backwards for the beginning of the set of filters, where
         // the last one invokes the provided continuation, the previous one invokes the last one, and so on,

--- a/src/Autofac.Integration.WebApi/ControllerTypeKey.cs
+++ b/src/Autofac.Integration.WebApi/ControllerTypeKey.cs
@@ -20,7 +20,10 @@ internal class ControllerTypeKey : IEquatable<ControllerTypeKey>
     /// <summary>
     /// Gets the type of the controller.
     /// </summary>
-    public Type ControllerType { get; private set; }
+    public Type ControllerType
+    {
+        get; private set;
+    }
 
     /// <summary>
     /// Determines whether the specified <see cref="object" /> is equal to the current <see cref="object" />.

--- a/src/Autofac.Integration.WebApi/ExceptionFilterOverrideWrapper.cs
+++ b/src/Autofac.Integration.WebApi/ExceptionFilterOverrideWrapper.cs
@@ -25,6 +25,9 @@ internal sealed class ExceptionFilterOverrideWrapper : ExceptionFilterWrapper, I
     /// </summary>
     public Type FiltersToOverride
     {
-        get { return typeof(IExceptionFilter); }
+        get
+        {
+            return typeof(IExceptionFilter);
+        }
     }
 }

--- a/src/Autofac.Integration.WebApi/FilterPredicateMetadata.cs
+++ b/src/Autofac.Integration.WebApi/FilterPredicateMetadata.cs
@@ -15,7 +15,10 @@ internal class FilterPredicateMetadata
     /// Gets or sets the callback that determines if a filter matches the action descriptor.
     /// Returns true/false to include the filter or not.
     /// </summary>
-    public Func<ILifetimeScope, HttpActionDescriptor, bool>? Predicate { get; set; }
+    public Func<ILifetimeScope, HttpActionDescriptor, bool>? Predicate
+    {
+        get; set;
+    }
 
     /// <summary>
     /// Gets or sets the scope of the filter.
@@ -23,10 +26,16 @@ internal class FilterPredicateMetadata
     /// <remarks>
     /// We need the scope of this filter registration so we can create the FilterInfo later.
     /// </remarks>
-    public FilterScope Scope { get; set; }
+    public FilterScope Scope
+    {
+        get; set;
+    }
 
     /// <summary>
     /// Gets or sets the filter category, used to group filters and control execution order.
     /// </summary>
-    public AutofacFilterCategory FilterCategory { get; set; }
+    public AutofacFilterCategory FilterCategory
+    {
+        get; set;
+    }
 }

--- a/src/Autofac.Integration.WebApi/HttpRequestMessageProvider.cs
+++ b/src/Autofac.Integration.WebApi/HttpRequestMessageProvider.cs
@@ -11,7 +11,7 @@ namespace Autofac.Integration.WebApi;
 /// </summary>
 internal static class HttpRequestMessageProvider
 {
-    private static readonly AsyncLocal<HttpRequestMessageHolder> CurrentRequest = new();
+    private static readonly AsyncLocal<HttpRequestMessageHolder> _currentRequest = new();
 
     /// <summary>
     /// Gets or sets the current request message.
@@ -23,23 +23,21 @@ internal static class HttpRequestMessageProvider
     {
         get
         {
-            return CurrentRequest.Value?.Message;
+            return _currentRequest.Value?._message;
         }
 
         set
         {
-            var holder = CurrentRequest.Value;
-            if (holder != null)
-            {
-                // Clear current HttpRequestMessage trapped in the AsyncLocals, as its done.
-                holder.Message = null;
-            }
+            var holder = _currentRequest.Value;
+
+            // Clear current HttpRequestMessage trapped in the AsyncLocals, as its done.
+            holder?._message = null;
 
             if (value != null)
             {
                 // Use an object indirection to hold the HttpRequestMessage in the AsyncLocal,
                 // so it can be cleared in all ExecutionContexts when its cleared.
-                CurrentRequest.Value = new HttpRequestMessageHolder { Message = value };
+                _currentRequest.Value = new HttpRequestMessageHolder { _message = value };
             }
         }
     }
@@ -47,6 +45,6 @@ internal static class HttpRequestMessageProvider
     private sealed class HttpRequestMessageHolder
     {
         [SuppressMessage("SA1401", "SA1401", Justification = "Field is only used during testing.")]
-        public HttpRequestMessage? Message;
+        public HttpRequestMessage? _message;
     }
 }

--- a/src/Autofac.Integration.WebApi/RegistrationExtensions.cs
+++ b/src/Autofac.Integration.WebApi/RegistrationExtensions.cs
@@ -1076,7 +1076,7 @@ public static class RegistrationExtensions
         registration.ValidateFilterType<TFilter>();
 
         // Get the filter metadata set.
-        registration = registration.GetOrCreateMetadata(out FilterMetadata filterMeta);
+        registration = registration.GetOrCreateMetadata(out var filterMeta);
 
         var registrationMetadata = new FilterPredicateMetadata
         {
@@ -1116,7 +1116,7 @@ public static class RegistrationExtensions
         registration.ValidateActionFilterType(out var isLegacyFilterType);
 
         // Get the filter metadata set.
-        registration = registration.GetOrCreateMetadata(out FilterMetadata filterMeta);
+        registration = registration.GetOrCreateMetadata(out var filterMeta);
 
         var registrationMetadata = new FilterPredicateMetadata
         {
@@ -1143,7 +1143,7 @@ public static class RegistrationExtensions
         registration.ValidateFilterType<TFilter>();
 
         // Get the filter metadata set.
-        registration = registration.GetOrCreateMetadata(out FilterMetadata filterMeta);
+        registration = registration.GetOrCreateMetadata(out var filterMeta);
 
         var registrationMetadata = new FilterPredicateMetadata
         {
@@ -1169,7 +1169,7 @@ public static class RegistrationExtensions
         registration.ValidateActionFilterType(out var isLegacyFilterType);
 
         // Get the filter metadata set.
-        registration = registration.GetOrCreateMetadata(out FilterMetadata filterMeta);
+        registration = registration.GetOrCreateMetadata(out var filterMeta);
 
         var registrationMetadata = new FilterPredicateMetadata
         {
@@ -1250,7 +1250,7 @@ public static class RegistrationExtensions
         registration.ValidateFilterType<TFilter>();
 
         // Get the filter metadata set.
-        registration = registration.GetOrCreateMetadata(out FilterMetadata filterMeta);
+        registration = registration.GetOrCreateMetadata(out var filterMeta);
 
         var registrationMetadata = new FilterPredicateMetadata
         {
@@ -1329,7 +1329,7 @@ public static class RegistrationExtensions
         registration.ValidateActionFilterType(out var isLegacyFilterType);
 
         // Get the filter metadata set.
-        registration = registration.GetOrCreateMetadata(out FilterMetadata filterMeta);
+        registration = registration.GetOrCreateMetadata(out var filterMeta);
 
         var registrationMetadata = new FilterPredicateMetadata
         {

--- a/test/Autofac.Integration.WebApi.Test/AutofacControllerConfigurationAttributeFixture.cs
+++ b/test/Autofac.Integration.WebApi.Test/AutofacControllerConfigurationAttributeFixture.cs
@@ -40,7 +40,7 @@ public class AutofacControllerConfigurationAttributeFixture
     {
         var builder = new ContainerBuilder();
         var service = Substitute.For<IHttpActionSelector>();
-        int callCount = 0;
+        var callCount = 0;
         builder.Register(c => service)
             .As<IHttpActionSelector>()
             .InstancePerApiControllerType(typeof(TestController))

--- a/test/Autofac.Integration.WebApi.Test/TestTypes/CustomActionFilterAttribute.cs
+++ b/test/Autofac.Integration.WebApi.Test/TestTypes/CustomActionFilterAttribute.cs
@@ -9,7 +9,10 @@ namespace Autofac.Integration.WebApi.Test.TestTypes;
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, Inherited = true, AllowMultiple = true)]
 public sealed class CustomActionFilterAttribute : ActionFilterAttribute
 {
-    public ILogger Logger { get; set; }
+    public ILogger Logger
+    {
+        get; set;
+    }
 
     public override void OnActionExecuting(HttpActionContext actionContext)
     {

--- a/test/Autofac.Integration.WebApi.Test/TestTypes/TestActionFilter.cs
+++ b/test/Autofac.Integration.WebApi.Test/TestTypes/TestActionFilter.cs
@@ -8,7 +8,10 @@ namespace Autofac.Integration.WebApi.Test.TestTypes;
 
 public class TestActionFilter : IAutofacActionFilter
 {
-    public ILogger Logger { get; private set; }
+    public ILogger Logger
+    {
+        get; private set;
+    }
 
     public TestActionFilter(ILogger logger)
     {

--- a/test/Autofac.Integration.WebApi.Test/TestTypes/TestActionFilter2.cs
+++ b/test/Autofac.Integration.WebApi.Test/TestTypes/TestActionFilter2.cs
@@ -8,7 +8,10 @@ namespace Autofac.Integration.WebApi.Test.TestTypes;
 
 public class TestActionFilter2 : IAutofacActionFilter
 {
-    public ILogger Logger { get; private set; }
+    public ILogger Logger
+    {
+        get; private set;
+    }
 
     public TestActionFilter2(ILogger logger)
     {

--- a/test/Autofac.Integration.WebApi.Test/TestTypes/TestActionFilter3.cs
+++ b/test/Autofac.Integration.WebApi.Test/TestTypes/TestActionFilter3.cs
@@ -8,7 +8,10 @@ namespace Autofac.Integration.WebApi.Test.TestTypes;
 
 public class TestActionFilter3 : IAutofacActionFilter
 {
-    public ILogger Logger { get; private set; }
+    public ILogger Logger
+    {
+        get; private set;
+    }
 
     public TestActionFilter3(ILogger logger)
     {

--- a/test/Autofac.Integration.WebApi.Test/TestTypes/TestActionFilterWithResponse.cs
+++ b/test/Autofac.Integration.WebApi.Test/TestTypes/TestActionFilterWithResponse.cs
@@ -10,7 +10,10 @@ namespace Autofac.Integration.WebApi.Test.TestTypes;
 
 public class TestActionFilterWithResponse : IAutofacActionFilter
 {
-    public ILogger Logger { get; private set; }
+    public ILogger Logger
+    {
+        get; private set;
+    }
 
     public TestActionFilterWithResponse(ILogger logger)
     {

--- a/test/Autofac.Integration.WebApi.Test/TestTypes/TestAuthenticationFilter.cs
+++ b/test/Autofac.Integration.WebApi.Test/TestTypes/TestAuthenticationFilter.cs
@@ -7,7 +7,10 @@ namespace Autofac.Integration.WebApi.Test.TestTypes;
 
 public class TestAuthenticationFilter : IAutofacAuthenticationFilter
 {
-    public ILogger Logger { get; private set; }
+    public ILogger Logger
+    {
+        get; private set;
+    }
 
     public TestAuthenticationFilter(ILogger logger)
     {

--- a/test/Autofac.Integration.WebApi.Test/TestTypes/TestAuthenticationFilter2.cs
+++ b/test/Autofac.Integration.WebApi.Test/TestTypes/TestAuthenticationFilter2.cs
@@ -7,7 +7,10 @@ namespace Autofac.Integration.WebApi.Test.TestTypes;
 
 public class TestAuthenticationFilter2 : IAutofacAuthenticationFilter
 {
-    public ILogger Logger { get; private set; }
+    public ILogger Logger
+    {
+        get; private set;
+    }
 
     public TestAuthenticationFilter2(ILogger logger)
     {

--- a/test/Autofac.Integration.WebApi.Test/TestTypes/TestAuthorizationFilter.cs
+++ b/test/Autofac.Integration.WebApi.Test/TestTypes/TestAuthorizationFilter.cs
@@ -7,7 +7,10 @@ namespace Autofac.Integration.WebApi.Test.TestTypes;
 
 public class TestAuthorizationFilter : IAutofacAuthorizationFilter
 {
-    public ILogger Logger { get; private set; }
+    public ILogger Logger
+    {
+        get; private set;
+    }
 
     public TestAuthorizationFilter(ILogger logger)
     {

--- a/test/Autofac.Integration.WebApi.Test/TestTypes/TestAuthorizationFilter2.cs
+++ b/test/Autofac.Integration.WebApi.Test/TestTypes/TestAuthorizationFilter2.cs
@@ -7,7 +7,10 @@ namespace Autofac.Integration.WebApi.Test.TestTypes;
 
 public class TestAuthorizationFilter2 : IAutofacAuthorizationFilter
 {
-    public ILogger Logger { get; private set; }
+    public ILogger Logger
+    {
+        get; private set;
+    }
 
     public TestAuthorizationFilter2(ILogger logger)
     {

--- a/test/Autofac.Integration.WebApi.Test/TestTypes/TestExceptionFilter.cs
+++ b/test/Autofac.Integration.WebApi.Test/TestTypes/TestExceptionFilter.cs
@@ -7,7 +7,10 @@ namespace Autofac.Integration.WebApi.Test.TestTypes;
 
 public class TestExceptionFilter : IAutofacExceptionFilter
 {
-    public ILogger Logger { get; private set; }
+    public ILogger Logger
+    {
+        get; private set;
+    }
 
     public TestExceptionFilter(ILogger logger)
     {

--- a/test/Autofac.Integration.WebApi.Test/TestTypes/TestExceptionFilter2.cs
+++ b/test/Autofac.Integration.WebApi.Test/TestTypes/TestExceptionFilter2.cs
@@ -7,7 +7,10 @@ namespace Autofac.Integration.WebApi.Test.TestTypes;
 
 public class TestExceptionFilter2 : IAutofacExceptionFilter
 {
-    public ILogger Logger { get; private set; }
+    public ILogger Logger
+    {
+        get; private set;
+    }
 
     public TestExceptionFilter2(ILogger logger)
     {

--- a/test/Autofac.Integration.WebApi.Test/TestTypes/TestModelBinder.cs
+++ b/test/Autofac.Integration.WebApi.Test/TestTypes/TestModelBinder.cs
@@ -8,7 +8,10 @@ namespace Autofac.Integration.WebApi.Test.TestTypes;
 
 public class TestModelBinder : IModelBinder
 {
-    public Dependency Dependency { get; private set; }
+    public Dependency Dependency
+    {
+        get; private set;
+    }
 
     public TestModelBinder(Dependency dependency)
     {


### PR DESCRIPTION
## Summary

- Standardize `.pre-commit-config.yaml`, `.editorconfig`, `build/stylecop.json`, `build/Source.ruleset`, `build/Test.ruleset` to match Autofac core
- Update `default.proj` Package target to pack individual projects
- Apply `dotnet format` code formatting

## Test plan

- [ ] CI build passes
- [ ] All tests pass
- [ ] `pre-commit run --all-files` passes